### PR TITLE
Revamp the AWS KMS implementation of the Secrets interface.

### DIFF
--- a/aws/aws_kms.go
+++ b/aws/aws_kms.go
@@ -1,12 +1,16 @@
 package aws
 
 import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
 	"encoding/base64"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
-	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
@@ -14,24 +18,45 @@ import (
 	"github.com/aws/aws-sdk-go/service/kms"
 	"github.com/libopenstorage/secrets"
 	sc "github.com/libopenstorage/secrets/aws/credentials"
+	"github.com/portworx/kvdb"
 )
 
 const (
-	Name               = "aws-kms"
-	AwsAccessKey       = "AWS_ACCESS_KEY_ID"
+	// Name of the secret store
+	Name = "aws-kms"
+	// AwsAccessKey corresponds to AWS credential AWS_ACCESS_KEY_ID
+	AwsAccessKey = "AWS_ACCESS_KEY_ID"
+	// AwsSecretAccessKey corresponds to AWS credential AWS_SECRET_ACCESS_KEY
 	AwsSecretAccessKey = "AWS_SECRET_ACCESS_KEY"
-	AwsTokenKey        = "AWS_SECRET_TOKEN_KEY"
-	AwsRegionKey       = "AWS_REGION"
-	AwsCMKey           = "AWS_CMK"
-	SecretKey          = "secret/"
+	// AwsTokenKey correspinds to AWS credential AWS_SECRET_TOKEN_KEY
+	AwsTokenKey = "AWS_SECRET_TOKEN_KEY"
+	// AwsRegionKey defines the AWS region
+	AwsRegionKey = "AWS_REGION"
+	// AwsCMKKey defines the KMS customer master key
+	AwsCMKKey = "AWS_CMK"
+	// KMSKvdbKey is used to setup AWS KMS Secret Store with kvdb for persistence.
+	KMSKvdbKey               = "KMS_KVDB"
+	kvdbPublicBasePath       = "aws_kms/secrets/public/"
+	kvdbDataBasePath         = "aws_kms/secrets/data/"
+	filePersistenceStoreName = "filePersistenceStore"
+	kvdbPersistenceStoreName = "kvdbPersistenceStore"
 )
 
 var (
-	ErrAwsAccessKeyNotSet       = errors.New("AWS_ACCESS_KEY_ID not set.")
+	// ErrAwsAccessKeyNotSet is returned when AWS credential for ACCESS_KEY is not set
+	ErrAwsAccessKeyNotSet = errors.New("AWS_ACCESS_KEY_ID not set.")
+	// ErrAwsSecretAccessKeyNotSet is returned when AWS credential for SECRET_KEY is not set
 	ErrAwsSecretAccessKeyNotSet = errors.New("AWS_SECRET_ACCESS_KEY not set.")
-	ErrInvalidSecretId          = errors.New("No Secret Data found for Secret Id")
-	ErrCMKNotProvided           = errors.New("AWS CMK not provided. Cannot perform KMS operations.")
-	ErrAWSRegionNotProvided     = errors.New("AWS Region not provided. Cannot perform KMS operations.")
+	// ErrInvalidSecret is returned when no secret data is found for given secret id
+	ErrInvalidSecretId = errors.New("No Secret Data found for Secret Id")
+	// ErrCMKNotProvided is returned when CMK is not provided.
+	ErrCMKNotProvided = errors.New("AWS CMK not provided. Cannot perform KMS operations.")
+	// ErrAWSRegionNotProvided is returned when region is not provided.
+	ErrAWSRegionNotProvided = errors.New("AWS Region not provided. Cannot perform KMS operations.")
+	// ErrInvalidKvdbProvided is returned when an incorrect KVDB implementation is provided for persistence store.
+	ErrInvalidKvdbProvided = errors.New("Invalid kvdb provided. AWS KMS works in conjuction with a kvdb")
+	// ErrInvalidRequest is returned when a request to get/put SecretData is made without configuring KVDB as a persistence store.
+	ErrInvalidRequest = errors.New("Storing secret data is supported in AWS KMS only if provided with kvdb as persistence store.")
 )
 
 type awsKmsSecrets struct {
@@ -40,10 +65,354 @@ type awsKmsSecrets struct {
 	sess   *session.Session
 	cmk    string
 	asc    sc.AWSCredentials
+	ps     persistenceStore
 }
 
-func getSecretKey(secretId string) string {
-	return SecretKey + secretId
+type persistenceStore interface {
+	// getPublic return the persisted aws kms public info
+	// of the given secretId
+	getPublic(secretId string) ([]byte, error)
+
+	// getSecretData returns the encrypted persisted secretData
+	// if it exists for the given secretId
+	getSecretData(secretId string, plain []byte) (map[string]interface{}, error)
+
+	// exists checks if the given secretId already
+	// exists
+	exists(secretId string) (bool, error)
+
+	// set persists the aws kms public info
+	// of the given secretId
+	set(secretId string, cipher, plain []byte, secretData map[string]interface{}) error
+
+	// name returns the name of persistence store
+	name() string
+}
+
+type filePersistenceStore struct{}
+
+func (f *filePersistenceStore) getPublic(secretId string) ([]byte, error) {
+	var path string
+
+	path = secrets.SecretPath + secretId
+	return ioutil.ReadFile(path)
+}
+
+func (f *filePersistenceStore) getSecretData(
+	secretId string,
+	plain []byte,
+) (map[string]interface{}, error) {
+	return nil, ErrInvalidRequest
+}
+
+func (f *filePersistenceStore) set(
+	secretId string,
+	cipher []byte,
+	plain []byte,
+	secretData map[string]interface{},
+) error {
+	if secretData != nil {
+		return ErrInvalidRequest
+	}
+
+	path := secrets.SecretPath + secretId
+	os.MkdirAll(secrets.SecretPath, 0700)
+	file, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	_, err = file.Write(cipher)
+	return err
+}
+
+func (f *filePersistenceStore) exists(secretId string) (bool, error) {
+	path := secrets.SecretPath + secretId
+	if checkValidPath(path) {
+		return true, nil
+	}
+	return false, nil
+}
+
+func (f *filePersistenceStore) name() string {
+	return filePersistenceStoreName
+}
+
+type kvdbPersistenceStore struct {
+	kv kvdb.Kvdb
+}
+
+func (k *kvdbPersistenceStore) getPublic(secretId string) ([]byte, error) {
+	key := kvdbPublicBasePath + secretId
+
+	// Get the public cipher
+	kvp, err := k.kv.Get(key)
+	if err != nil {
+		return nil, err
+	}
+	return kvp.Value, nil
+}
+
+func (k *kvdbPersistenceStore) getSecretData(
+	secretId string,
+	plain []byte,
+) (map[string]interface{}, error) {
+	dataKey := kvdbDataBasePath + secretId
+
+	// Check if there exists a key
+	kvp, err := k.kv.Get(dataKey)
+	if err == kvdb.ErrNotFound {
+		return nil, nil
+	} else if err != nil {
+		return nil, err
+	}
+
+	// base4 decode the encrypted data stored in kvdb.
+	decodedEncryptedData, err := base64.StdEncoding.DecodeString(string(kvp.Value))
+	if err != nil {
+		return nil, err
+	}
+
+	// decrypt the encrypted data.
+	decryptedData, err := decrypt(decodedEncryptedData, plain)
+	if err != nil {
+		return nil, fmt.Errorf("Unable to decrypt secret data: %v", err)
+	}
+
+	secretData := make(map[string]interface{})
+	// unmarshal the data into a map
+	err = json.Unmarshal(decryptedData, &secretData)
+	if err != nil {
+		return nil, fmt.Errorf("Unable to unmarshal decrypted secret data: %v", err)
+	}
+	return secretData, nil
+}
+
+func (k *kvdbPersistenceStore) set(
+	secretId string,
+	cipher []byte,
+	plain []byte,
+	secretData map[string]interface{},
+) error {
+	key := kvdbPublicBasePath + secretId
+	// Save the public cipher
+	_, err := k.kv.Put(key, cipher, 0)
+	if err != nil {
+		return err
+	}
+	if secretData == nil {
+		return nil
+	}
+
+	// marshal the input map into a byte array
+	data, err := json.Marshal(&secretData)
+	if err != nil {
+		return err
+	}
+
+	// Use the plaintext cipher to encrypt the
+	// marshaled secretData
+	encryptedData, err := encrypt(data, plain)
+	if err != nil {
+		return err
+	}
+
+	// encode the encrypted data and store it in kvdb
+	encodedEncryptedData := base64.StdEncoding.EncodeToString(encryptedData)
+
+	dataKey := kvdbDataBasePath + secretId
+	_, err = k.kv.Put(dataKey, encodedEncryptedData, 0)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (k *kvdbPersistenceStore) exists(secretId string) (bool, error) {
+	key := kvdbPublicBasePath + secretId
+	_, err := k.kv.Get(key)
+	if err == nil {
+		return true, nil
+	} else if err == kvdb.ErrNotFound {
+		return false, nil
+	}
+	return false, err
+}
+
+func (k *kvdbPersistenceStore) name() string {
+	return kvdbPersistenceStoreName
+}
+
+func New(
+	secretConfig map[string]interface{},
+) (secrets.Secrets, error) {
+	if secretConfig == nil {
+		return nil, ErrCMKNotProvided
+	}
+	var ps persistenceStore
+
+	v, _ := secretConfig[AwsCMKKey]
+	cmk, _ := v.(string)
+	if cmk == "" {
+		return nil, ErrCMKNotProvided
+	}
+	v, _ = secretConfig[AwsRegionKey]
+	region, _ := v.(string)
+	if region == "" {
+		return nil, ErrAWSRegionNotProvided
+	}
+	v, ok := secretConfig[KMSKvdbKey]
+	if ok {
+		kv, ok := v.(kvdb.Kvdb)
+		if !ok {
+			return nil, ErrInvalidKvdbProvided
+		}
+		ps = &kvdbPersistenceStore{kv}
+	} else {
+		ps = &filePersistenceStore{}
+	}
+
+	id, secret, token, err := authKeys(secretConfig)
+	if err != nil {
+		return nil, err
+	}
+	asc, err := sc.NewAWSCredentials(id, secret, token)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get credentials: %v", err)
+	}
+	creds, err := asc.Get()
+	if err != nil {
+		return nil, fmt.Errorf("Failed to get credentials: %v", err)
+	}
+	config := &aws.Config{
+		Credentials: creds,
+		Region:      &region,
+	}
+	sess := session.New(config)
+	kmsClient := kms.New(sess)
+	return &awsKmsSecrets{
+		client: kmsClient,
+		sess:   sess,
+		creds:  creds,
+		cmk:    cmk,
+		asc:    asc,
+		ps:     ps,
+	}, nil
+}
+
+func (a *awsKmsSecrets) String() string {
+	return Name
+}
+
+func (a *awsKmsSecrets) GetSecret(
+	secretId string,
+	keyContext map[string]string,
+) (map[string]interface{}, error) {
+	var (
+		cipherBlob, decodedCipherBlob []byte
+		secretData                    map[string]interface{}
+	)
+
+	if exists, err := a.ps.exists(secretId); err == nil && !exists {
+		return nil, secrets.ErrInvalidSecretId
+	} else if err != nil {
+		return nil, err
+	}
+
+	cipherBlob, err := a.ps.getPublic(secretId)
+	if err != nil {
+		return nil, err
+	}
+	// AWS KMS api requires the cipherBlob to be in base64 decoded format.
+	// Check if it is encoded and decode if required.
+	decodedCipherBlob, err = base64.StdEncoding.DecodeString(string(cipherBlob))
+	if err != nil {
+		decodedCipherBlob = cipherBlob
+	}
+	input := &kms.DecryptInput{
+		EncryptionContext: getAWSKeyContext(keyContext),
+		CiphertextBlob:    decodedCipherBlob,
+	}
+	output, err := a.client.Decrypt(input)
+	if err != nil {
+		return nil, err
+	}
+
+	// filePersistenceStore does not support storing of secretData
+	if a.ps.name() == filePersistenceStoreName {
+		goto return_plaintext
+	}
+
+	// check if kvdbPersistenceStore has any secretData stored for this
+	// secretId
+	secretData, err = a.ps.getSecretData(secretId, output.Plaintext)
+	if err == nil && secretData != nil {
+		return secretData, nil
+	} else if err != nil {
+		return nil, err
+	}
+
+return_plaintext:
+	secretData = make(map[string]interface{})
+	secretData[secretId] = string(output.Plaintext)
+	return secretData, nil
+}
+
+func (a *awsKmsSecrets) PutSecret(
+	secretId string,
+	secretData map[string]interface{},
+	keyContext map[string]string,
+) error {
+
+	if exists, err := a.ps.exists(secretId); exists && err == nil {
+		return secrets.ErrSecretExists
+	} else if err != nil {
+		return err
+	}
+
+	keySpec := "AES_256"
+	input := &kms.GenerateDataKeyInput{
+		KeyId:             &a.cmk,
+		EncryptionContext: getAWSKeyContext(keyContext),
+		KeySpec:           &keySpec,
+	}
+
+	output, err := a.client.GenerateDataKey(input)
+	if err != nil {
+		return err
+	}
+
+	return a.ps.set(
+		secretId,
+		output.CiphertextBlob,
+		output.Plaintext,
+		secretData,
+	)
+}
+
+func (a *awsKmsSecrets) Encrypt(
+	secretId string,
+	plaintTextData string,
+	keyContext map[string]string,
+) (string, error) {
+	return "", secrets.ErrNotSupported
+}
+
+func (a *awsKmsSecrets) Decrypt(
+	secretId string,
+	encryptedData string,
+	keyContext map[string]string,
+) (string, error) {
+	return "", secrets.ErrNotSupported
+}
+
+func (a *awsKmsSecrets) Rencrypt(
+	originalSecretId string,
+	newSecretId string,
+	originalKeyContext map[string]string,
+	newKeyContext map[string]string,
+	encryptedData string,
+) (string, error) {
+	return "", secrets.ErrNotSupported
 }
 
 func authKeys(params map[string]interface{}) (string, string, string, error) {
@@ -77,174 +446,6 @@ func getAuthKey(key string, params map[string]interface{}) (string, error) {
 	return valueStr, nil
 }
 
-func New(
-	secretConfig map[string]interface{},
-) (secrets.Secrets, error) {
-	if secretConfig == nil {
-		return nil, ErrCMKNotProvided
-	}
-
-	v, _ := secretConfig[AwsCMKey]
-	cmk, _ := v.(string)
-	if cmk == "" {
-		return nil, ErrCMKNotProvided
-	}
-	v, _ = secretConfig[AwsRegionKey]
-	region, _ := v.(string)
-	if region == "" {
-		return nil, ErrAWSRegionNotProvided
-	}
-
-	id, secret, token, err := authKeys(secretConfig)
-	if err != nil {
-		return nil, err
-	}
-	asc, err := sc.NewAWSCredentials(id, secret, token)
-	if err != nil {
-		return nil, fmt.Errorf("Failed to get credentials: %v", err)
-	}
-	creds, err := asc.Get()
-	if err != nil {
-		return nil, fmt.Errorf("Failed to get credentials: %v", err)
-	}
-	config := &aws.Config{
-		Credentials: creds,
-		Region:      &region,
-	}
-	sess := session.New(config)
-	kmsClient := kms.New(sess)
-	return &awsKmsSecrets{
-		client: kmsClient,
-		sess:   sess,
-		creds:  creds,
-		cmk:    cmk,
-		asc:    asc,
-	}, nil
-}
-
-func (a *awsKmsSecrets) String() string {
-	return Name
-}
-
-func (a *awsKmsSecrets) GetSecret(
-	secretId string,
-	keyContext map[string]string,
-) (map[string]interface{}, error) {
-	var (
-		path        string
-		secretIdKey string
-	)
-	if checkValidPath(secretId) {
-		path = secretId
-		secretIdKey = getIdFromPath(path)
-	} else {
-		path = secrets.SecretPath + secretId
-		secretIdKey = secretId
-	}
-
-	var (
-		cipherBlob, decodedCipherBlob []byte
-	)
-	_, err := os.Stat(path)
-
-	if err == nil || os.IsExist(err) {
-		cipherBlob, err = ioutil.ReadFile(path)
-		if err != nil {
-			return nil, fmt.Errorf("Invalid secretId. Unable to read cipherBlob"+
-				" associated with secretId: %v", err)
-		}
-	}
-	// EncryptedDataKey passed in as an argument
-	if len(cipherBlob) == 0 {
-		cipherBlob = []byte(secretId)
-	}
-	// AWS KMS api requires the cipherBlob to be in base64 decoded format.
-	// Check if it is encoded and decode if required.
-	decodedCipherBlob, err = base64.StdEncoding.DecodeString(string(cipherBlob))
-	if err != nil {
-		decodedCipherBlob = cipherBlob
-	}
-	input := &kms.DecryptInput{
-		EncryptionContext: getAWSKeyContext(keyContext),
-		CiphertextBlob:    decodedCipherBlob,
-	}
-	output, err := a.client.Decrypt(input)
-	if err != nil {
-		return nil, err
-	}
-	secretData := make(map[string]interface{})
-	secretData[secretIdKey] = string(output.Plaintext)
-	return secretData, nil
-}
-
-func (a *awsKmsSecrets) PutSecret(
-	secretId string,
-	secretData map[string]interface{},
-	keyContext map[string]string,
-) error {
-	if checkValidPath(secretId) {
-		return secrets.ErrSecretExists
-	}
-	if secretData != nil {
-		return fmt.Errorf("AWS KMS does not support storing of custom secret data")
-	}
-	keySpec := "AES_256"
-	input := &kms.GenerateDataKeyInput{
-		KeyId:             &a.cmk,
-		EncryptionContext: getAWSKeyContext(keyContext),
-		KeySpec:           &keySpec,
-	}
-	path := secrets.SecretPath + secretId
-	if checkValidPath(path) {
-		return secrets.ErrSecretExists
-	}
-
-	output, err := a.client.GenerateDataKey(input)
-	if err != nil {
-		return err
-	}
-
-	os.MkdirAll(secrets.SecretPath, 0700)
-	f, err := os.Create(path)
-	if err != nil {
-		return err
-	}
-	_, err = f.Write(output.CiphertextBlob)
-	return err
-}
-
-func (a *awsKmsSecrets) Encrypt(
-	secretId string,
-	plaintTextData string,
-	keyContext map[string]string,
-) (string, error) {
-	return "", secrets.ErrNotSupported
-}
-
-func (a *awsKmsSecrets) Decrypt(
-	secretId string,
-	encryptedData string,
-	keyContext map[string]string,
-) (string, error) {
-	return "", secrets.ErrNotSupported
-}
-
-func (a *awsKmsSecrets) Rencrypt(
-	originalSecretId string,
-	newSecretId string,
-	originalKeyContext map[string]string,
-	newKeyContext map[string]string,
-	encryptedData string,
-) (string, error) {
-	return "", secrets.ErrNotSupported
-}
-
-func init() {
-	if err := secrets.Register(Name, New); err != nil {
-		panic(err.Error())
-	}
-}
-
 func getAWSKeyContext(keyContext map[string]string) map[string]*string {
 	if keyContext == nil {
 		return nil
@@ -264,11 +465,53 @@ func checkValidPath(path string) bool {
 
 }
 
-func getIdFromPath(path string) string {
-	path = strings.TrimSuffix(path, "/")
-	tokens := strings.Split(path, "/")
-	if len(tokens) == 0 {
-		return path
+// encrypt encrypts the data using the passphrase
+func encrypt(data, passphrase []byte) ([]byte, error) {
+	gcm, err := getGCM(passphrase)
+	if err != nil {
+		return nil, err
 	}
-	return tokens[len(tokens)-1]
+
+	nonce := make([]byte, gcm.NonceSize())
+
+	if _, err = io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, err
+	}
+
+	return gcm.Seal(nonce, nonce, data, nil), nil
+}
+
+// decrypt decrypts the cipherData using the passphrase
+func decrypt(cipherData, passphrase []byte) ([]byte, error) {
+	gcm, err := getGCM(passphrase)
+	if err != nil {
+		return nil, err
+	}
+
+	nonceSize := gcm.NonceSize()
+
+	if len(cipherData) < nonceSize {
+		return nil, errors.New("ciphertext too short")
+	}
+
+	nonce, cipherData := cipherData[:nonceSize], cipherData[nonceSize:]
+	decryptedData, err := gcm.Open(cipherData[:0], nonce, cipherData, nil)
+	return decryptedData, err
+}
+
+// getGCM returns golang's AEAD, a cipher mode for AES encryption
+// using Galois/Counter Mode (GCM)
+func getGCM(passphrase []byte) (cipher.AEAD, error) {
+	c, err := aes.NewCipher(passphrase)
+	if err != nil {
+		return nil, err
+	}
+
+	return cipher.NewGCM(c)
+}
+
+func init() {
+	if err := secrets.Register(Name, New); err != nil {
+		panic(err.Error())
+	}
 }

--- a/aws/aws_kms_test.go
+++ b/aws/aws_kms_test.go
@@ -1,25 +1,43 @@
 package aws
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
 	"github.com/libopenstorage/secrets"
 	"github.com/libopenstorage/secrets/test"
+	"github.com/portworx/kvdb"
+	"github.com/portworx/kvdb/mem"
 )
 
 const (
-	secretId = "openstorage_secret"
+	secretIdWithData    = "openstorage_secret_data"
+	secretIdWithoutData = "openstorage_secret"
 )
 
 func TestAll(t *testing.T) {
 	// Set the relevant environmnet fields for aws.
 	secretConfig := make(map[string]interface{})
 	// Fill in the appropriate keys and values
-	secretConfig[AwsCMKey] = "<cmk>"
-	secretConfig[AwsRegionKey] = "<region>"
+	secretConfig[AwsCMKKey] = os.Getenv(AwsCMKKey)
+	secretConfig[AwsRegionKey] = os.Getenv(AwsRegionKey)
+
+	os.RemoveAll(secrets.SecretPath + secretIdWithoutData)
+	// With filePersistenceStore
 	as, err := NewAwsSecretTest(secretConfig)
+	if err != nil {
+		t.Fatalf("Unable to create a AWS Secret instance: %v", err)
+		return
+	}
+	test.Run(as, t)
+
+	// With kvdbPersistenceStore
+	kv, err := kvdb.New(mem.Name, "openstorage/", nil, nil, nil)
+	if err != nil {
+		t.Fatalf("Unable to create a AWS Secret instance: %v", err)
+	}
+	secretConfig[KMSKvdbKey] = kv
+	as, err = NewAwsSecretTest(secretConfig)
 	if err != nil {
 		t.Fatalf("Unable to create a AWS Secret instance: %v", err)
 		return
@@ -42,31 +60,26 @@ func NewAwsSecretTest(secretConfig map[string]interface{}) (test.SecretTest, err
 func (a *awsSecretTest) TestPutSecret(t *testing.T) error {
 	secretData := make(map[string]interface{})
 	secretData["key1"] = "value1"
+	secretData["key2"] = "value2"
 	// PutSecret with non-nil secretData
-	err := a.s.PutSecret(secretId, secretData, nil)
-	if err == nil {
-		t.Errorf("Expected PutSecret to fail. SecretData should always be null")
+	err := a.s.PutSecret(secretIdWithData, secretData, nil)
+	if err != nil && err != ErrInvalidRequest {
+		t.Errorf("Expected PutSecret to not fail.: %v", err)
 	}
 
-	// A successful PutSecret
-	err = a.s.PutSecret(secretId, nil, nil)
+	// PutSecret with nil secretData
+	err = a.s.PutSecret(secretIdWithoutData, nil, nil)
 	if err != nil {
 		t.Errorf("Expected PutSecret to succeed. Failed with error: %v", err)
 	}
-	// Check if file with encrypted blob is created
-	_, err = os.Stat(secrets.SecretPath + secretId)
-	if os.IsNotExist(err) {
-		t.Errorf("Expected PutSecret to write a file with cipher text blob")
-	}
 
 	// PutSecret with already existing secretId
-	err = a.s.PutSecret(secretId, nil, nil)
-	if err != secrets.ErrSecretExists {
+	err = a.s.PutSecret(secretIdWithData, secretData, nil)
+	if err != secrets.ErrSecretExists && err != ErrInvalidRequest {
 		t.Errorf("Expected PutSecret to fail with ErrSecretExists error")
 	}
 
-	// PutSecret with input as a file path which already exists
-	err = a.s.PutSecret(secrets.SecretPath+secretId, nil, nil)
+	err = a.s.PutSecret(secretIdWithoutData, nil, nil)
 	if err != secrets.ErrSecretExists {
 		t.Errorf("Expected PutSecret to fail with ErrSecretExists error")
 	}
@@ -81,68 +94,32 @@ func (a *awsSecretTest) TestGetSecret(t *testing.T) error {
 		t.Errorf("Expected GetSecret to fail. Invalid secretId")
 	}
 
-	// GetSecret using a secretId
-	plainText1, err := a.s.GetSecret(secretId, nil)
-	if err != nil {
+	// GetSecret using a secretId with data
+	plainText1, err := a.s.GetSecret(secretIdWithData, nil)
+	if err != nil && err != secrets.ErrInvalidSecretId {
 		t.Errorf("Expected GetSecret to succeed. Failed with error: %v", err)
-	}
-	if plainText1 == nil || len(plainText1) != 1 {
-		t.Errorf("Invalid PlainText was returned")
-	}
-
-	path := secrets.SecretPath + secretId
-	cipherBlob := []byte{}
-	_, err = os.Stat(path)
-	if err == nil || os.IsExist(err) {
-		cipherBlob, err = ioutil.ReadFile(path)
-		if err != nil {
-			t.Errorf("Unable to read file")
+	} else if err == nil {
+		// We have got secretData
+		if plainText1 == nil {
+			t.Errorf("Invalid PlainText was returned")
+		}
+		v, ok := plainText1["key1"]
+		if !ok {
+			t.Errorf("Unexpected secretData")
+		}
+		str, ok := v.(string)
+		if !ok {
+			t.Errorf("Unexpected secretData")
+		}
+		if str != "value1" {
+			t.Errorf("Unexpected secretData")
 		}
 	}
-	// GetSecret with id as the actual cipherblob
-	plainText2, err := a.s.GetSecret(string(cipherBlob), nil)
+
+	// GetSecret using a secretId without data
+	_, err = a.s.GetSecret(secretIdWithoutData, nil)
 	if err != nil {
 		t.Errorf("Expected GetSecret to succeed. Failed with error: %v", err)
 	}
-	if plainText2 == nil || len(plainText2) != 1 {
-		t.Errorf("Invalid PlainText was returned")
-	}
-
-	checkPlainTextEquality(plainText1, plainText2, t)
-
-	// GetSecret with id as a file path where the cipherblob is present
-	plainText3, err := a.s.GetSecret(path, nil)
-	if err != nil {
-		t.Errorf("Expected GetSecret to succeed. Failed with error: %v", err)
-	}
-	if plainText3 == nil || len(plainText3) != 1 {
-		t.Errorf("Invalid PlainText was returned")
-	}
-
-	checkPlainTextEquality(plainText1, plainText3, t)
 	return nil
-}
-
-func checkPlainTextEquality(plainText1, plainText2 map[string]interface{}, t *testing.T) {
-	if len(plainText1) != len(plainText2) {
-		t.Errorf("Plaintext lengths do no match")
-	}
-	var (
-		pT1, pT2 interface{}
-	)
-	for _, v := range plainText1 {
-		pT1 = v
-		break
-	}
-	for _, v := range plainText2 {
-		pT2 = v
-		break
-	}
-	if pT1 == nil || pT2 == nil {
-		t.Errorf("Plaintext is null")
-	}
-
-	if len(pT1.([]byte)) != len(pT2.([]byte)) {
-		t.Errorf("Plain text do not match")
-	}
 }

--- a/aws/aws_kms_test.go
+++ b/aws/aws_kms_test.go
@@ -19,7 +19,7 @@ func TestAll(t *testing.T) {
 	// Set the relevant environmnet fields for aws.
 	secretConfig := make(map[string]interface{})
 	// Fill in the appropriate keys and values
-	secretConfig[AwsCMKKey] = os.Getenv(AwsCMKKey)
+	secretConfig[AwsCMKey] = os.Getenv(AwsCMKey)
 	secretConfig[AwsRegionKey] = os.Getenv(AwsRegionKey)
 
 	os.RemoveAll(secrets.SecretPath + secretIdWithoutData)
@@ -35,6 +35,7 @@ func TestAll(t *testing.T) {
 	kv, err := kvdb.New(mem.Name, "openstorage/", nil, nil, nil)
 	if err != nil {
 		t.Fatalf("Unable to create a AWS Secret instance: %v", err)
+		return
 	}
 	secretConfig[KMSKvdbKey] = kv
 	as, err = NewAwsSecretTest(secretConfig)

--- a/secrets.go
+++ b/secrets.go
@@ -8,7 +8,7 @@ var (
 	// ErrNotSupported returned when implementation of specific function is not supported
 	ErrNotSupported = errors.New("implementation not supported")
 	// ErrNotAuthenticated returned when not authenticated with secrets endpoint
-	ErrNotAuthenticated  = errors.New("Not authenticated with the secrets endpoint")
+	ErrNotAuthenticated = errors.New("Not authenticated with the secrets endpoint")
 	// ErrInvalidSecretId returned when no secret data is found associated with the id
 	ErrInvalidSecretId = errors.New("No Secret Data found for Secret Id")
 	// ErrSecretExists returned when a secret for the given secret id already exists


### PR DESCRIPTION
AWS KMS cannot act as a secret store where we can store user data.
It provides a mechanism to generate DataKeys that could be used
for encrypting user data. In KMS when you generate a DataKey it returns
1. [Private Key]: PlainText which should be used for encrypting data.
2. [Public Key]: CipherText which should be used for subsequent calls to KMS to fetch the private key.

- Add two persistence stores for AWS KMS to store the public key
  - filePersistenceStore - uses files on host
  - kvdbPersistenceStore - uses a key value database using portworx/kvdb

- Add support for storing user data in a secret store
  - AWS KMS in conjunction with kvdb can store user data.
  - For every secretData to be stored, a new DataKey is generated in KMS.
  - PutSecret -> Using the private key and AES+GCM algorithm, the user data is encrypted and then stored in kvdb.
  - GetSecret -> Using the public key, the private key is fetched from KMS. The encrypted data stored in kvdb is then fetched
                 and using the same AES with GCM algorithm is used to decrypt the user data.