### PR TITLE
Integrate with IBM Key Protect

### DIFF
--- a/ibm/README.md
+++ b/ibm/README.md
@@ -1,0 +1,8 @@
+# To run UTs
+1. Create a Key Protect Service in the US South region.
+2. Create a Root Key
+3. Get the Service API Key and the Instance ID using the steps describe under pkg/ibm/README.md
+
+```
+$ IBM_SERVICE_API_KEY=<api_key> IBM_INSTANCE_ID=<instance_id> IBM_CUSTOMER_ROOT_KEY=<crk>
+```

--- a/ibm/ibm_key_protect.go
+++ b/ibm/ibm_key_protect.go
@@ -53,7 +53,7 @@ type ibmKPSecret struct {
 func New(
 	secretConfig map[string]interface{},
 ) (secrets.Secrets, error) {
-	if secretConfig == nil {
+	if len(secretConfig) == 0 {
 		return nil, ErrIbmServiceApiKeyNotSet
 	}
 	v, _ := secretConfig[IbmCustomerRootKey]
@@ -76,10 +76,13 @@ func New(
 	v, ok := secretConfig[IbmKvdbKey]
 	if ok {
 		kv, ok = v.(kvdb.Kvdb)
-		if !ok {
+		if !ok || kv == nil {
 			return nil, ErrInvalidKvdbProvided
 		}
+	} else {
+		return nil, ErrInvalidKvdbProvided
 	}
+
 	ps := store.NewKvdbPersistenceStore(kv, kvdbPublicBasePath, kvdbDataBasePath)
 
 	v, _ = secretConfig[IbmBaseUrlKey]

--- a/ibm/ibm_key_protect.go
+++ b/ibm/ibm_key_protect.go
@@ -1,0 +1,214 @@
+package ibm
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+
+	"github.com/libopenstorage/secrets"
+	"github.com/libopenstorage/secrets/pkg/ibm"
+	"github.com/libopenstorage/secrets/pkg/store"
+	"github.com/portworx/kvdb"
+	"github.com/sirupsen/logrus"
+)
+
+const (
+	// Name of the secret store
+	Name = "ibm-kp"
+	// IbmServiceApiKey is the service ID API Key
+	IbmServiceApiKey = "IBM_SERVICE_API_KEY"
+	// IbmInstanceIdKey is the Key Protect Service's Instance ID
+	IbmInstanceIdKey = "IBM_INSTANCE_ID"
+	// IbmBaseUrlKey is the Key Protect Service's Base URL
+	IbmBaseUrlKey = "IBM_BASE_URL"
+	// IbmTokenUrlKey is the Key Protect Service's Token URL
+	IbmTokenUrlKey = "IBM_TOKEN_URL"
+	// IbmCustomerRootKey is the Customer Root Key used for obtaining DEKs
+	IbmCustomerRootKey = "IBM_CUSTOMER_ROOT_KEY"
+	// IbmKvdbKey is used to setup IBM Key Protect Secret Store with kvdb for persistence.
+	IbmKvdbKey         = "IBM_KVDB"
+	kvdbPublicBasePath = "ibm_kp/secrets/public/"
+	kvdbDataBasePath   = "ibm_kp/secrets/data/"
+)
+
+var (
+	// ErrIbmServiceApiKeyNotSet is returned when IBM_SERVICE_API_KEY is not set
+	ErrIbmServiceApiKeyNotSet = errors.New("IBM_SERVICE_API_KEY not set.")
+	// ErrIbmInstanceIdKeyNotSet is returned when IBM_INSTANCE_ID is not set
+	ErrIbmInstanceIdKeyNotSet = errors.New("IBM_INSTANCE_ID not set.")
+	// ErrCRKNotProvided is returned when Customer Root Key is not provided.
+	ErrCRKNotProvided = errors.New("IBM Customer Root Key not provided. Cannot perform Key Protect operations.")
+	// ErrInvalidKvdbProvided is returned when an incorrect KVDB implementation is provided for persistence store.
+	ErrInvalidKvdbProvided = errors.New("Invalid kvdb provided. IBM Key Protect secret store works in conjuction with a kvdb")
+	// ErrInvalidSecretData is returned when no secret data is found
+	ErrInvalidSecretData = errors.New("Secret Data cannot be empty")
+)
+
+type ibmKPSecret struct {
+	kp  *ibm.API
+	ps  store.PersistenceStore
+	crk string
+}
+
+func New(
+	secretConfig map[string]interface{},
+) (secrets.Secrets, error) {
+	if secretConfig == nil {
+		return nil, ErrIbmServiceApiKeyNotSet
+	}
+	v, _ := secretConfig[IbmCustomerRootKey]
+	crk, _ := v.(string)
+	if crk == "" {
+		return nil, ErrCRKNotProvided
+	}
+	v, _ = secretConfig[IbmServiceApiKey]
+	serviceApiKey, _ := v.(string)
+	if serviceApiKey == "" {
+		return nil, ErrIbmServiceApiKeyNotSet
+	}
+	v, _ = secretConfig[IbmInstanceIdKey]
+	instanceId, _ := v.(string)
+	if instanceId == "" {
+		return nil, ErrIbmInstanceIdKeyNotSet
+	}
+
+	var kv kvdb.Kvdb
+	v, ok := secretConfig[IbmKvdbKey]
+	if ok {
+		kv, ok = v.(kvdb.Kvdb)
+		if !ok {
+			return nil, ErrInvalidKvdbProvided
+		}
+	}
+	ps := store.NewKvdbPersistenceStore(kv, kvdbPublicBasePath, kvdbDataBasePath)
+
+	v, _ = secretConfig[IbmBaseUrlKey]
+	baseUrl, _ := v.(string)
+	if baseUrl == "" {
+		baseUrl = ibm.DefaultBaseURL
+	}
+
+	v, _ = secretConfig[IbmTokenUrlKey]
+	tokenUrl, _ := v.(string)
+	if tokenUrl == "" {
+		tokenUrl = ibm.DefaultTokenURL
+	}
+
+	cc := ibm.ClientConfig{
+		BaseURL:    baseUrl,
+		APIKey:     serviceApiKey,
+		TokenURL:   tokenUrl,
+		InstanceID: instanceId,
+		Verbose:    ibm.VerboseAll,
+	}
+	kp, err := ibm.NewAPIWithLogger(cc, nil, logrus.StandardLogger())
+	if err != nil {
+		return nil, err
+	}
+	return &ibmKPSecret{
+		kp:  kp,
+		crk: crk,
+		ps:  ps,
+	}, nil
+}
+
+func (i *ibmKPSecret) String() string {
+	return Name
+}
+
+func (i *ibmKPSecret) GetSecret(
+	secretId string,
+	keyContext map[string]string,
+) (map[string]interface{}, error) {
+	if exists, err := i.ps.Exists(secretId); err != nil {
+		return nil, err
+	} else if !exists {
+		return nil, secrets.ErrInvalidSecretId
+	}
+
+	// Get the DEK (Data Encryption Key) from kvdb
+	dek, err := i.ps.GetPublic(secretId)
+	if err != nil {
+		return nil, err
+	}
+
+	// Use the CRK to unwrap the DEK and get the secret passphrase
+	encodedPassphrase, err := i.kp.Unwrap(
+		context.Background(),
+		i.crk,
+		dek,
+		nil,
+	)
+	decodedPassphrase, err := base64.StdEncoding.DecodeString(string(encodedPassphrase))
+	if err != nil {
+		return nil, err
+	}
+
+	secretData := make(map[string]interface{})
+	secretData[secretId] = string(decodedPassphrase)
+	return secretData, nil
+}
+
+func (i *ibmKPSecret) PutSecret(
+	secretId string,
+	secretData map[string]interface{},
+	keyContext map[string]string,
+) error {
+	if len(secretData) == 0 {
+		return ErrInvalidSecretData
+	}
+	v, _ := secretData[secretId]
+	passphrase := v.(string)
+	if passphrase == "" {
+		return ErrInvalidSecretData
+	}
+
+	encodedPassphrase := base64.StdEncoding.EncodeToString([]byte(passphrase))
+	dek, err := i.kp.Wrap(
+		context.Background(),
+		i.crk,
+		[]byte(encodedPassphrase),
+		nil,
+	)
+	if err != nil {
+		return err
+	}
+	return i.ps.Set(
+		secretId,
+		dek,
+		nil,
+		nil,
+	)
+}
+
+func (i *ibmKPSecret) Encrypt(
+	secretId string,
+	plaintTextData string,
+	keyContext map[string]string,
+) (string, error) {
+	return "", secrets.ErrNotSupported
+}
+
+func (i *ibmKPSecret) Decrypt(
+	secretId string,
+	encryptedData string,
+	keyContext map[string]string,
+) (string, error) {
+	return "", secrets.ErrNotSupported
+}
+
+func (i *ibmKPSecret) Rencrypt(
+	originalSecretId string,
+	newSecretId string,
+	originalKeyContext map[string]string,
+	newKeyContext map[string]string,
+	encryptedData string,
+) (string, error) {
+	return "", secrets.ErrNotSupported
+}
+
+func init() {
+	if err := secrets.Register(Name, New); err != nil {
+		panic(err.Error())
+	}
+}

--- a/ibm/ibm_key_protect_test.go
+++ b/ibm/ibm_key_protect_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/pborman/uuid"
 	"github.com/portworx/kvdb"
 	"github.com/portworx/kvdb/mem"
+	"github.com/stretchr/testify/assert"
 )
 
 const (
@@ -16,7 +17,7 @@ const (
 )
 
 func TestAll(t *testing.T) {
-	// Set the relevant environmnet fields for aws.
+	// Set the relevant environment fields for ibm kp.
 	secretConfig := make(map[string]interface{})
 	// Fill in the appropriate keys and values
 	secretConfig[IbmServiceApiKey] = os.Getenv(IbmServiceApiKey)
@@ -28,7 +29,7 @@ func TestAll(t *testing.T) {
 	// With kvdbPersistenceStore
 	kv, err := kvdb.New(mem.Name, "openstorage/", nil, nil, nil)
 	if err != nil {
-		t.Fatalf("Unable to create a AWS Secret instance: %v", err)
+		t.Fatalf("Unable to create a IBM Key Protect Secret instance: %v", err)
 		return
 	}
 	secretConfig[IbmKvdbKey] = kv
@@ -101,4 +102,57 @@ func (i *ibmSecretTest) TestGetSecret(t *testing.T) error {
 		}
 	}
 	return nil
+}
+
+func TestNew(t *testing.T) {
+	// nil secret config
+	_, err := New(nil)
+	assert.EqualError(t, err, ErrIbmServiceApiKeyNotSet.Error(), "Unexpected error on nil secret config")
+
+	// empty secret config
+	secretConfig := make(map[string]interface{})
+	_, err = New(secretConfig)
+	assert.EqualError(t, err, ErrIbmServiceApiKeyNotSet.Error(), "Unexpected error on empty secret config")
+
+	// crk not provided
+	secretConfig[IbmServiceApiKey] = "foo"
+	secretConfig[IbmInstanceIdKey] = "bar"
+	_, err = New(secretConfig)
+	assert.EqualError(t, err, ErrCRKNotProvided.Error(), "Unepxected error when CRK not provided")
+
+	// service api key not provided
+	secretConfig[IbmCustomerRootKey] = "bar1"
+	delete(secretConfig, IbmServiceApiKey)
+	_, err = New(secretConfig)
+	assert.EqualError(t, err, ErrIbmServiceApiKeyNotSet.Error(), "Unexpected error when Service API Key not provided")
+
+	// instance id not provided
+	secretConfig[IbmServiceApiKey] = "foo"
+	delete(secretConfig, IbmInstanceIdKey)
+	_, err = New(secretConfig)
+	assert.EqualError(t, err, ErrIbmInstanceIdKeyNotSet.Error(), "Unexpected error when Instance ID Key not provided")
+
+	// kvdb key not provided
+	secretConfig[IbmInstanceIdKey] = "bar"
+	_, err = New(secretConfig)
+	assert.EqualError(t, err, ErrInvalidKvdbProvided.Error(), "Unepxected error when Kvdb Key not provided")
+
+	// kvdb key is incorrect
+	secretConfig[IbmKvdbKey] = "dummy"
+	_, err = New(secretConfig)
+	assert.EqualError(t, err, ErrInvalidKvdbProvided.Error(), "Unepxected error when Kvdb Key not provided")
+
+	// With kvdbPersistenceStore
+	kv, err := kvdb.New(mem.Name, "openstorage/", nil, nil, nil)
+	if err != nil {
+		t.Fatalf("Unable to create a IBM Key Protect Secret instance: %v", err)
+		return
+	}
+
+	// kvdb key is correct
+	secretConfig[IbmKvdbKey] = kv
+	kp, err := New(secretConfig)
+	assert.NotNil(t, kp, "Expected New API to succeed")
+	assert.NoError(t, err, "Unepxected error on New")
+
 }

--- a/ibm/ibm_key_protect_test.go
+++ b/ibm/ibm_key_protect_test.go
@@ -1,0 +1,104 @@
+package ibm
+
+import (
+	"os"
+	"testing"
+
+	"github.com/libopenstorage/secrets"
+	"github.com/libopenstorage/secrets/test"
+	"github.com/pborman/uuid"
+	"github.com/portworx/kvdb"
+	"github.com/portworx/kvdb/mem"
+)
+
+const (
+	testSecretId = "openstorage_secret"
+)
+
+func TestAll(t *testing.T) {
+	// Set the relevant environmnet fields for aws.
+	secretConfig := make(map[string]interface{})
+	// Fill in the appropriate keys and values
+	secretConfig[IbmServiceApiKey] = os.Getenv(IbmServiceApiKey)
+	secretConfig[IbmInstanceIdKey] = os.Getenv(IbmInstanceIdKey)
+	secretConfig[IbmCustomerRootKey] = os.Getenv(IbmCustomerRootKey)
+	secretConfig[IbmBaseUrlKey] = os.Getenv(IbmBaseUrlKey)
+	secretConfig[IbmTokenUrlKey] = os.Getenv(IbmTokenUrlKey)
+
+	// With kvdbPersistenceStore
+	kv, err := kvdb.New(mem.Name, "openstorage/", nil, nil, nil)
+	if err != nil {
+		t.Fatalf("Unable to create a AWS Secret instance: %v", err)
+		return
+	}
+	secretConfig[IbmKvdbKey] = kv
+	kp, err := New(secretConfig)
+	if err != nil {
+		t.Fatalf("Unable to create a IBM Key Protect Secret instance: %v", err)
+		return
+	}
+	ik := &ibmSecretTest{kp, ""}
+	test.Run(ik, t)
+}
+
+type ibmSecretTest struct {
+	s          secrets.Secrets
+	passphrase string
+}
+
+func (i *ibmSecretTest) TestPutSecret(t *testing.T) error {
+
+	secretData := make(map[string]interface{})
+	i.passphrase = uuid.New()
+	secretData[testSecretId] = i.passphrase
+	// PutSecret with non-nil secretData
+	err := i.s.PutSecret(testSecretId, secretData, nil)
+	if err != nil {
+		t.Errorf("Expected PutSecret to not fail.: %v", err)
+	}
+
+	// PutSecret with nil secretData
+	err = i.s.PutSecret(testSecretId, nil, nil)
+	if err == nil {
+		t.Errorf("Expected PutSecret to return with an error")
+	}
+
+	// PutSecret with already existing secretId
+	err = i.s.PutSecret(testSecretId, secretData, nil)
+	if err != nil {
+		t.Errorf("Expected PutSecret to fail with ErrSecretExists error")
+	}
+
+	return nil
+}
+
+func (i *ibmSecretTest) TestGetSecret(t *testing.T) error {
+	// GetSecret with non-existant id
+	_, err := i.s.GetSecret("dummy", nil)
+	if err == nil {
+		t.Errorf("Expected GetSecret to fail. Invalid secretId")
+	}
+
+	// GetSecret using a secretId with data
+	plainText1, err := i.s.GetSecret(testSecretId, nil)
+	if err != nil && err != secrets.ErrInvalidSecretId {
+		t.Errorf("Expected GetSecret to succeed. Failed with error: %v", err)
+	} else if err == nil {
+		// We have got secretData
+		if plainText1 == nil {
+			t.Errorf("Invalid PlainText was returned")
+		}
+		v, ok := plainText1[testSecretId]
+		if !ok {
+			t.Errorf("Unexpected secretData")
+		}
+		str, ok := v.(string)
+		if !ok {
+			t.Errorf("Unexpected secretData")
+		}
+		if str != i.passphrase {
+			t.Errorf("Unexpected secretData")
+		}
+	}
+	return nil
+}

--- a/pkg/ibm/README.md
+++ b/pkg/ibm/README.md
@@ -1,4 +1,4 @@
-The pkg ibm is provides a golang REST client to talk with IBM's Key Protect Service.
+The pkg ibm provides a golang REST client to talk with IBM's Key Protect Service.
 It has been provided to us by the IKS team.
 Thanks to Karna Bojjireddy (karub@us.ibm.com) and Sandip Amin (samin@us.ibm.com) for providing this library.
 

--- a/pkg/ibm/README.md
+++ b/pkg/ibm/README.md
@@ -1,0 +1,173 @@
+The pkg ibm is provides a golang REST client to talk with IBM's Key Protect Service.
+It has been provided to us by the IKS team.
+Thanks to Karna Bojjireddy (karub@us.ibm.com) and Sandip Amin (samin@us.ibm.com) for providing this library.
+
+# Key Protect Service Client
+
+## Usage
+
+This client requires that you have an existing IBM Cloud Key Protect Service, for more information see:
+https://console.bluemix.net/catalog/services/key-protect/.  Note: The client currently only supports
+key protect service instances and not the older cloud foundry service instances.  Support for cloud foundry instances
+may be added in the future.
+
+The key protect service requires a valid IAM access token or a service id API Key.  When using your own token, it's the responsibilty
+of the caller to ensure the access token is valid and is not expired.  You can specify the access token in either the client configuration
+structure or on the context (see below).  If you specify an APIKey, the client calls IAM to get an access token for that API key and reuses
+that token on subsequent calls. If the API key token is expired, the client will call IAM to get a new access token.
+
+To use the client you will need the following:
+
+* Access Token
+  * Either an IBM Cloud access token which you can get by doing the following in the bx cli:
+    * Login
+    * Once logged, run `bx iam oauth-tokens`.  The `IAM token` is what you need, including the words `Bearer`.
+  * Or a service ID API key.  For more information on creating an API key see the key protect documentation:
+https://console.bluemix.net/docs/services/keymgmt/keyprotect_authentication.html#retrieve_token.  Follow steps 1-3
+to get an API key.  You do NOT have the get an access token from the API key as the client will take care of that for you.
+* The UUID of the key protect service:
+  * Run the following commands:
+    * `bx resource service-instances`
+    * Find your key protect service ID by running the following:
+      * `bx resource service-instance <name of your key protect service>`
+      * The ID will look something like this:
+        ```
+        ID:                    crn:v1:bluemix:public:kms:us-south:a/fb474855a3e76c1ce3aaebf57e0f1a9f:0647c737-blah1-blah2-8a68-2c187e11b29b::
+        ```
+        This ID is the full CRN.  You need to specify just id portion which is everything between the last `:` and `::`, in this example
+        the id to use is: `0647c737-906d-blah1-blah2-2c187e11b29b`
+
+Once you have those pieces of information, you can create a client as follows:
+Note: BaseURL specifies the URL where your key protect instance resides.  It is region specific.  See Config.go DefaultBaseURL for a sample.
+Note: There are 3 ways to provide the authorization token.
+1. In the ClientConfig structure specify the `APIKey` and the `TokenURL` attributes.  A default token url can be found in config.go DefaultTokenURL.
+The client will take care of obtaining an access token.
+2. In the ClientConfig structure specify the `Authorization` attribute.  All key protect API calls using that client will use that authorization token.
+3. In the context on each call. You can create an authorization context by using the `kp.NewContextWithAuth()` function.  If you specify more
+than 1 authentication method, the precedence is:
+   1. Context
+   1. Authorization in the ClientConfig structure
+   1. API key in the ClientConfig structure
+
+```
+// Create the client config using your API key
+
+c := kp.ClientConfig{
+		BaseURL:       kp.DefaultBaseURL,
+	  APIKey:        "<api-key>",
+		TokenURL:      DefaultTokenURL,
+		InstanceID:    "<instance-id>",
+		Verbose:       kp.VerboseAll,
+	}
+
+// Create the API.  You can specify your own http transport object or use a default one provided by the client.
+
+api := kp.NewAPI(c, kp.DefaultTransport())
+
+// Now you can call the apis
+
+keys, err := api.GetKeys(context.Background(), 0, 0)
+....
+```
+
+To specify authorization token on the context:
+
+```
+// Create the client config with authorization
+
+c := kp.ClientConfig{
+		BaseURL:       kp.DefaultBaseURL,
+		InstanceID:    "<instance-id>",
+		Verbose:       kp.VerboseAll,
+	}
+
+// Create the API.  You can specify your own http transport object or use a default one provided by the client.
+
+api := kp.NewAPI(c, kp.DefaultTransport())
+
+ctx := kp.NewContextWithAuth(context.Background(), "Bearer <auth info>")
+
+// Now you can call the apis
+
+keys, err := api.GetKeys(ctx, 0, 0)
+....
+```
+
+## Generating a root key (CRK)
+
+```
+//Create a root key named MyRootKey with no expiration
+key, err := api.CreateRootKey(ctx, "MyRootKey", nil)
+if err != nil {
+    fmt.Println(err)
+}
+fmt.Println(key.ID, key.Name)
+
+crkID := key.ID
+```
+
+## Wrapping and Unwrapping a DEK using a specific Root Key.
+
+```
+myDEK := []byte{"thisisadataencryptionkey"}
+// Do some encryption with myDEK
+// Wrap the DEK so we can safely store it
+wrappedDEK, err := api.Wrap(ctx, crkID, myDEK, nil)
+
+
+//Unwrap the DEK
+dek, err := api.UnWrap(ctx, crkID, wrappedDEK, nil)
+//Do some encryption/decryption using the DEK
+//Discard the DEK
+dek = nil
+
+```
+
+Note you can also pass additional authentication data (AAD) to wrap and unwrap calls
+to provide another level of protection for your DEK.  The AAD is a string array with
+each element up to 255 chars.  For example:
+
+```
+myAAD := []string{"First aad string", "second aad string", "third aad string"}
+myDEK := []byte{"thisisadataencryptionkey"}
+// Do some encryption with myDEK
+// Wrap the DEK so we can safely store it
+wrappedDEK, err := api.Wrap(ctx, crkID, myDEK, &myAAD)
+
+
+//Unwrap the DEK
+dek, err := api.UnWrap(ctx, crkID, wrappedDEK, &myAAD)
+//Do some encryption/decryption using the DEK
+//Discard the DEK
+dek = nil
+
+```
+
+Have key protect create a DEK for you:
+
+```
+
+dek, wrappedDek, err := api.WrapCreateDEK(ctx, crkID, nil)
+//Do some encrypt/decrypt with the dek
+//Discard the DEK
+dek = nil
+
+//Save the wrapped DEK for later.  Use Unwrap to use it.
+
+```
+
+Can also specify AAD:
+
+```
+myAAD := []string{"First aad string", "second aad string", "third aad string"}
+dek, wrappedDek, err := api.WrapCreateDEK(ctx, crkID, &myAAD)
+//Do some encrypt/decrypt with the dek
+//Discard the DEK
+dek = nil
+
+//Save the wrapped DEK for later.  Call Unwrap to use it, make
+//sure to specify the same AAD.
+
+```
+
+## Running the test cases

--- a/pkg/ibm/api.go
+++ b/pkg/ibm/api.go
@@ -1,0 +1,544 @@
+package ibm
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type dumpFunction func(*http.Request, *http.Response, []byte, []byte, logger, []string)
+type contextKey int
+type redactFunction func(string, []string) string
+
+const (
+	// ReturnMinimal ...
+	ReturnMinimal ReturnInfo = 0
+	// ReturnRepresentation ...
+	ReturnRepresentation ReturnInfo = 1
+	authContextKey       contextKey = 0
+	keyType                         = "application/vnd.ibm.kms.key+json"
+	defaultTimeout                  = 5 // in seconds.
+)
+
+var preferHeader = [...]string{"return=minimal", "return=representation"}
+var dumpFunctions = [...]dumpFunction{dumpNone, dumpBodyOnly, dumpAll, dumpFailOnly, dumpAllNoRedact}
+
+// ReturnInfo ...
+type ReturnInfo int
+
+// Logger Interface
+type logger interface {
+	Info(args ...interface{})
+}
+
+// API ..
+type API struct {
+	URL        *url.URL
+	HttpClient http.Client
+	Headers    http.Header
+	Dump       dumpFunction
+	Config     ClientConfig
+	AuthToken  AuthToken
+	Logger     logger
+}
+
+// Key ...
+type Key struct {
+	ID            string     `json:"id,omitempty"`
+	Name          string     `json:"name,omitempty"`
+	Description   string     `json:"description,omitempty"`
+	Type          string     `json:"type,omitempty"`
+	Tags          []string   `json:"Tags,omitempty"`
+	AlgorithmType string     `json:"algorithmType,omitempty"`
+	CreatedBy     string     `json:"createdBy,omitempty"`
+	CreationDate  *time.Time `json:"creationDate,omitempty"`
+	Extractable   bool       `json:"extractable"`
+	Expiration    *time.Time `json:"expirationDate,omitempty"`
+	Payload       string     `json:"payload,omitempty"`
+	State         int        `json:"state,omitempty"`
+}
+
+// KeysMetaData ...
+type KeysMetaData struct {
+	CollectionType string `json:"collectionType"`
+	NumberOfKeys   int    `json:"collectionTotal"`
+}
+
+// Keys ...
+type Keys struct {
+	Metadata KeysMetaData `json:"metadata"`
+	Keys     []Key        `json:"resources"`
+}
+
+// KeysAction ...
+type KeysAction struct {
+	PlainText  string   `json:"plaintext,omitempty"`
+	AAD        []string `json:"aad,omitempty"`
+	CipherText string   `json:"ciphertext,omitempty"`
+}
+
+// AuthToken ...
+type AuthToken struct {
+	AccessToken      string `json:"access_token,omitempty"`
+	RefreshToken     string `json:"refresh_token,omitempty"`
+	ExpiresInSeconds int    `json:"expires_in"`
+	Type             string `json:"token_type"`
+	expiration       time.Time
+}
+
+// NewAPI ...
+func NewAPI(config ClientConfig, transport http.RoundTripper) (*API, error) {
+	return NewAPIWithLogger(config, transport, nil)
+}
+
+// NewAPIWithLogger ...
+func NewAPIWithLogger(config ClientConfig, transport http.RoundTripper, logger logger) (*API, error) {
+	//TODO Add some config validation
+	if transport == nil {
+		transport = DefaultTransport()
+	}
+	if logger == nil {
+		logger = &BasicLogger{}
+	}
+	if config.Verbose > len(dumpFunctions)-1 || config.Verbose < 0 {
+		return nil, errors.New("verbose value is out of range")
+	}
+	if config.Timeout == 0 {
+		config.Timeout = defaultTimeout
+	}
+	keysURL := fmt.Sprintf("%s/api/v2/", config.BaseURL)
+	u, err := url.Parse(keysURL)
+	if err != nil {
+		return nil, err
+	}
+	return &API{
+		URL: u,
+		HttpClient: http.Client{
+			Timeout:   time.Duration(config.Timeout * float64(time.Second)),
+			Transport: transport,
+		},
+		Headers: http.Header{
+			"bluemix-instance": {config.InstanceID},
+			"accept":           {"application/vnd.ibm.collection+json"},
+		},
+		Dump:   dumpFunctions[config.Verbose],
+		Config: config,
+		Logger: logger,
+	}, nil
+}
+
+// CreateRootKey ...
+func (a *API) CreateRootKey(ctx context.Context, name string, expiration *time.Time) (*Key, error) {
+
+	return a.Create(ctx, name, expiration, false)
+}
+
+// CreateStandardKey ...
+func (a *API) CreateStandardKey(ctx context.Context, name string, expiration *time.Time) (*Key, error) {
+	return a.Create(ctx, name, expiration, true)
+}
+
+// Delete ...
+func (a *API) Delete(ctx context.Context, id string, returnInfo ReturnInfo) (*Key, error) {
+	additionalHeader := http.Header{
+		"Prefer": {preferHeader[returnInfo]},
+	}
+
+	var keys Keys
+	err := a.doHTTPRequest(ctx, "DELETE", &id, nil, additionalHeader, nil, &keys)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(keys.Keys) > 0 {
+		return &keys.Keys[0], nil
+	}
+
+	return nil, nil
+}
+
+// GetKeys ...
+func (a *API) GetKeys(ctx context.Context, limit int, offset int) (*Keys, error) {
+
+	var keys Keys
+	v := url.Values{}
+	if limit == 0 {
+		limit = 2000
+	}
+	v.Set("limit", strconv.Itoa(limit))
+	v.Set("offset", strconv.Itoa(offset))
+
+	err := a.doHTTPRequest(ctx, "GET", nil, v, nil, nil, &keys)
+	return &keys, err
+}
+
+// GetKey ...
+func (a *API) GetKey(ctx context.Context, id string) (*Key, error) {
+
+	var keys Keys
+	err := a.doHTTPRequest(ctx, "GET", &id, nil, nil, nil, &keys)
+	if err != nil {
+		return nil, err
+	}
+	return &keys.Keys[0], nil
+}
+
+// Wrap ...
+func (a *API) Wrap(ctx context.Context, id string, plainText []byte, additionalAuthData *[]string) ([]byte, error) {
+
+	keysAction, err := a.wrapIt(ctx, id, plainText, additionalAuthData)
+	if err != nil {
+		return nil, err
+	}
+	return ([]byte)(keysAction.CipherText), nil
+}
+
+// WrapCreateDEK ...
+func (a *API) WrapCreateDEK(ctx context.Context, id string, additionalAuthData *[]string) (DEK, cipherText []byte, err error) {
+	keysAction, err := a.wrapIt(ctx, id, nil, additionalAuthData)
+	if err != nil {
+		return nil, nil, err
+	}
+	DEK = []byte(keysAction.PlainText)
+	return DEK, ([]byte)(keysAction.CipherText), nil
+}
+
+// Unwrap ...
+func (a *API) Unwrap(ctx context.Context, id string, cipherText []byte, additionalAuthData *[]string) (plainText []byte, err error) {
+	keysAction := &KeysAction{
+		CipherText: string(cipherText),
+	}
+
+	if additionalAuthData != nil {
+		keysAction.AAD = *additionalAuthData
+	}
+
+	keysAction, err = a.doKeysAction(ctx, &id, "unwrap", keysAction)
+	if err != nil {
+		return nil, err
+	}
+	plainText = []byte(keysAction.PlainText)
+	return plainText, nil
+}
+
+func (a *API) Create(ctx context.Context, name string, expiration *time.Time, extractable bool) (*Key, error) {
+
+	key := Key{
+		Name:        name,
+		Type:        keyType,
+		Extractable: extractable,
+	}
+	if expiration != nil {
+		key.Expiration = expiration
+	}
+	keysRequest := Keys{
+		Metadata: KeysMetaData{
+			CollectionType: keyType,
+			NumberOfKeys:   1,
+		},
+		Keys: make([]Key, 1),
+	}
+	keysRequest.Keys[0] = key
+	var keysResponse Keys
+	err := a.doHTTPRequest(ctx, "POST", nil, nil, nil, &keysRequest, &keysResponse)
+	if err != nil {
+		return nil, err
+	}
+	return &keysResponse.Keys[0], nil
+}
+
+func (a *API) wrapIt(ctx context.Context, id string, plainText []byte, additionalAuthData *[]string) (*KeysAction, error) {
+	keysAction := &KeysAction{}
+
+	if plainText != nil {
+		_, err := base64.StdEncoding.DecodeString(string(plainText))
+		if err != nil {
+			return nil, err
+		}
+		keysAction.PlainText = string(plainText)
+	}
+	if additionalAuthData != nil {
+		keysAction.AAD = *additionalAuthData
+	}
+	keysAction, err := a.doKeysAction(ctx, &id, "wrap", keysAction)
+	if err != nil {
+		return nil, err
+	}
+	return keysAction, nil
+}
+
+func (a *API) doKeysAction(ctx context.Context, id *string, action string, keysActionReq *KeysAction) (*KeysAction, error) {
+	var keyActionRsp KeysAction
+
+	v := url.Values{}
+	v.Set("action", action)
+
+	err := a.doHTTPRequest(ctx, "POST", id, v, nil, keysActionReq, &keyActionRsp)
+	if err != nil {
+		return nil, err
+	}
+	return &keyActionRsp, nil
+}
+
+func (a *API) doHTTPRequest(ctx context.Context, method string, id *string, queryParms url.Values, additionalHeaders http.Header, requestBody, responseBody interface{}) error {
+
+	url, err := a.keysURL(id)
+	if err != nil {
+		return err
+	}
+
+	if queryParms != nil {
+		url.RawQuery = queryParms.Encode()
+	}
+
+	var headers http.Header
+	acccesToken, err := a.getAccessToken(ctx)
+	if err != nil {
+		return err
+	}
+	if additionalHeaders != nil {
+		headers = cloneHeader(a.Headers)
+		headers = mergeHeaders(headers, additionalHeaders)
+	} else {
+		headers = a.Headers
+	}
+	headers.Set("authorization", acccesToken)
+
+	request := &http.Request{
+		Method: method,
+		URL:    url,
+		Header: headers,
+	}
+	var reqBody []byte
+	if requestBody != nil {
+		reqBody, err = json.Marshal(requestBody)
+		if err != nil {
+			return err
+		}
+		request.Body = ioutil.NopCloser(bytes.NewReader(reqBody))
+		defer request.Body.Close()
+	}
+
+	c := make(chan error, 1)
+	go func() { c <- a.sendRequest(request.WithContext(ctx), reqBody, responseBody) }()
+	select {
+	case <-ctx.Done():
+		<-c // Wait for sendRequest to return.
+		return ctx.Err()
+	case err := <-c:
+		return err
+	}
+}
+
+func (a *API) sendRequest(request *http.Request, requestBody []byte, responseBody interface{}) error {
+	// Error structure for KP.
+	type KPErrorMsg struct {
+		Message string `json:"errorMsg,omitempty"`
+	}
+	type KPError struct {
+		Resources []KPErrorMsg `json:"resources,ommitempty"`
+	}
+
+	// Error structure for IAM.
+	type IAMError struct {
+		Code    string `json:"errorCode,omitempty"`
+		Message string `json:"errorMessage, omitempty"`
+	}
+
+	response, err := a.HttpClient.Do(request)
+	if err != nil {
+		return err
+	}
+	defer response.Body.Close()
+	resBody, err := ioutil.ReadAll(response.Body)
+	redact := []string{a.AuthToken.AccessToken, a.Config.APIKey, request.Header.Get("authorization")}
+	a.Dump(request, response, requestBody, resBody, a.Logger, redact)
+	if err != nil {
+		return err
+	}
+
+	switch response.StatusCode {
+	case http.StatusOK, http.StatusCreated:
+		if err := json.Unmarshal(resBody, responseBody); err != nil {
+			return err
+		}
+		return nil
+	case http.StatusNoContent:
+		return nil
+	default:
+		if strings.Contains(string(resBody), "errorMsg") {
+			kperr := KPError{}
+			json.Unmarshal(resBody, &kperr)
+			if len(kperr.Resources) > 0 && len(kperr.Resources[0].Message) > 0 {
+				return errors.New(kperr.Resources[0].Message)
+			}
+		}
+		if strings.Contains(string(resBody), "errorCode") {
+			iamerr := IAMError{}
+			json.Unmarshal(resBody, &iamerr)
+			if len(iamerr.Message) > 0 {
+				return fmt.Errorf("%s:%s", iamerr.Code, iamerr.Message)
+			}
+		}
+		return errors.New(string(resBody))
+	}
+}
+
+func (a *API) keysURL(id *string) (*url.URL, error) {
+	keysURI := "keys"
+	if id != nil {
+		keysURI = fmt.Sprintf(keysURI+"/%s", *id)
+	}
+	u, err := url.Parse(keysURI)
+	if err != nil {
+		return nil, err
+	}
+
+	return a.URL.ResolveReference(u), nil
+}
+
+func (a *API) getAccessToken(ctx context.Context) (string, error) {
+
+	if ctx.Value(authContextKey) != nil {
+		return ctx.Value(authContextKey).(string), nil
+	}
+
+	if len(a.Config.Authorization) > 0 {
+		return a.Config.Authorization, nil
+	}
+
+	if len(a.AuthToken.AccessToken) > 0 && time.Now().Before(a.AuthToken.expiration) {
+		return fmt.Sprintf("%s %s", a.AuthToken.Type, a.AuthToken.AccessToken), nil
+	}
+
+	v := url.Values{}
+	v.Set("grant_type", "urn:ibm:params:oauth:grant-type:apikey")
+	v.Set("apikey", a.Config.APIKey)
+	reqBody := []byte(v.Encode())
+
+	u, err := url.Parse(a.Config.TokenURL)
+	if err != nil {
+		return "", err
+	}
+	request := &http.Request{
+		Method: "POST",
+		URL:    u,
+		Header: http.Header{
+			"Content-Type": {"application/x-www-form-urlencoded"},
+			"Accept":       {"application/json"},
+		},
+		Body: ioutil.NopCloser(bytes.NewReader(reqBody)),
+	}
+	defer request.Body.Close()
+
+	c := make(chan error, 1)
+	go func() { c <- a.sendRequest(request.WithContext(ctx), reqBody, &a.AuthToken) }()
+	select {
+	case <-ctx.Done():
+		<-c // Wait for sendRequest to return.
+		return "", ctx.Err()
+	case err := <-c:
+		if err != nil {
+			return "", err
+		}
+		//Set the expiration time for 1 min less than the actual time to prevent timeout errors
+		a.AuthToken.expiration = time.Now().Add(time.Second * time.Duration(a.AuthToken.ExpiresInSeconds-60))
+		return fmt.Sprintf("%s %s", a.AuthToken.Type, a.AuthToken.AccessToken), nil
+	}
+}
+
+func dumpFailOnly(req *http.Request, rsp *http.Response, reqBody, resBody []byte, log logger, redactStrings []string) {
+	switch rsp.StatusCode {
+	case http.StatusOK, http.StatusCreated, http.StatusNoContent:
+		return
+	}
+	dumpAll(req, rsp, reqBody, resBody, log, redactStrings)
+}
+
+func dumpAll(req *http.Request, rsp *http.Response, reqBody, resBody []byte, log logger, redactStrings []string) {
+	dumpRequest(req, rsp, log, redactStrings, doRedact)
+	dumpBody(reqBody, resBody, log, redactStrings, doRedact)
+}
+
+func dumpAllNoRedact(req *http.Request, rsp *http.Response, reqBody, resBody []byte, log logger, redactStrings []string) {
+	dumpRequest(req, rsp, log, redactStrings, noRedact)
+	dumpBody(reqBody, resBody, log, redactStrings, noRedact)
+}
+
+func dumpBodyOnly(req *http.Request, rsp *http.Response, reqBody, resBody []byte, log logger, redactStrings []string) {
+	dumpBody(reqBody, resBody, log, redactStrings, doRedact)
+}
+
+func dumpNone(req *http.Request, rsp *http.Response, reqBody, resBody []byte, log logger, redactStrings []string) {
+}
+
+func dumpRequest(req *http.Request, rsp *http.Response, log logger, redactStrings []string, redact redactFunction) {
+	// log.Info(redact(fmt.Sprint(req), redactStrings))
+	// log.Info(redact(fmt.Sprint(rsp), redactStrings))
+}
+
+func dumpBody(reqBody, resBody []byte, log logger, redactStrings []string, redact redactFunction) {
+	// log.Info(string(redact(string(reqBody), redactStrings)))
+	// Redact the access token and refresh token if it shows up in the reponnse body.  This will happen
+	// when using an API Key
+	var auth AuthToken
+	if strings.Contains(string(resBody), "access_token") {
+		err := json.Unmarshal(resBody, &auth)
+		if err != nil {
+			log.Info(err)
+		}
+		redactStrings = append(redactStrings, auth.AccessToken)
+		redactStrings = append(redactStrings, auth.RefreshToken)
+	}
+	// log.Info(string(redact(string(resBody), redactStrings)))
+}
+
+func cloneHeader(h http.Header) http.Header {
+	h2 := make(http.Header, len(h))
+	for k, vv := range h {
+		vv2 := make([]string, len(vv))
+		copy(vv2, vv)
+		h2[k] = vv2
+	}
+	return h2
+}
+
+func mergeHeaders(h1, h2 http.Header) http.Header {
+	for k, v := range h2 {
+		h1[k] = v
+	}
+	return h1
+}
+
+func doRedact(s string, redactStrings []string) string {
+	if len(redactStrings) < 1 {
+		return s
+	}
+	var a []string
+	for _, s1 := range redactStrings {
+		if s1 != "" {
+			a = append(a, s1)
+			a = append(a, "***Value redacted***")
+		}
+	}
+	r := strings.NewReplacer(a...)
+	return r.Replace(s)
+}
+
+func noRedact(s string, redactStrings []string) string {
+	return s
+}
+
+func testLogger() logger {
+	var l logger
+	return l
+}

--- a/pkg/ibm/config.go
+++ b/pkg/ibm/config.go
@@ -1,0 +1,49 @@
+package ibm
+
+import (
+	"context"
+	"net/http"
+)
+
+const (
+	// DefaultBaseURL ...
+	DefaultBaseURL = "https://keyprotect.us-south.bluemix.net"
+	// DefaultTokenURL ..
+	DefaultTokenURL = "https://iam.bluemix.net/oidc/token"
+
+	// VerboseNone ...
+	VerboseNone = 0
+	// VerboseBodyOnly ...
+	VerboseBodyOnly = 1
+	// VerboseAll ...
+	VerboseAll = 2
+	// VerboseFailOnly ...
+	VerboseFailOnly = 3
+	// VerboseAllNoRedact ...
+	VerboseAllNoRedact = 4
+)
+
+// ClientConfig ...
+type ClientConfig struct {
+	BaseURL       string
+	Authorization string  //The IBM Cloud (Bluemix) access token
+	APIKey        string  //Service ID API key, can be used instead of an access token
+	TokenURL      string  //The URL used to get an access token from the API key
+	InstanceID    string  //The IBM Cloud (Bluemix) instance ID that identifies your Key Protect service instance.
+	Verbose       int     //See verbose values above
+	Timeout       float64 //KP request timeout in seconds.
+}
+
+// DefaultTransport ...
+func DefaultTransport() http.RoundTripper {
+	transport := &http.Transport{
+		DisableKeepAlives:   true,
+		MaxIdleConnsPerHost: -1,
+	}
+	return transport
+}
+
+// NewContextWithAuth ...
+func NewContextWithAuth(parent context.Context, auth string) context.Context {
+	return context.WithValue(parent, authContextKey, auth)
+}

--- a/pkg/ibm/logger.go
+++ b/pkg/ibm/logger.go
@@ -1,0 +1,15 @@
+package ibm
+
+import (
+	"fmt"
+)
+
+// BasicLogger ...
+type BasicLogger struct{}
+
+// Info ...
+func (l *BasicLogger) Info(args ...interface{}) {
+	for _, arg := range args {
+		fmt.Println(arg)
+	}
+}

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -1,0 +1,22 @@
+package store
+
+type PersistenceStore interface {
+	// GetPublic returns the persisted kms public info
+	// of the given secretId
+	GetPublic(secretId string) ([]byte, error)
+
+	// GetSecretData returns the encrypted persisted secretData
+	// if it exists for the given secretId
+	GetSecretData(secretId string, plain []byte) (map[string]interface{}, error)
+
+	// Exists checks if the given secretId already
+	// exists
+	Exists(secretId string) (bool, error)
+
+	// Set persists the kms public info and encyrpted secretData if provided
+	// for the given secretId
+	Set(secretId string, cipher, plain []byte, secretData map[string]interface{}) error
+
+	// Name returns the name of persistence store
+	Name() string
+}

--- a/pkg/store/store_file.go
+++ b/pkg/store/store_file.go
@@ -1,0 +1,78 @@
+package store
+
+import (
+	"errors"
+	"io/ioutil"
+	"os"
+
+	"github.com/libopenstorage/secrets"
+)
+
+const (
+	filePersistenceStoreName = "filePersistenceStore"
+)
+
+var (
+	// ErrInvalidRequest is returned when a request to get/put SecretData is made without configuring KVDB as a persistence store.
+	ErrInvalidRequest = errors.New("Storing secret data is supported in AWS KMS only if provided with kvdb as persistence store.")
+)
+
+func NewFilePersistenceStore() PersistenceStore {
+	return &filePersistenceStore{}
+}
+
+type filePersistenceStore struct{}
+
+func (f *filePersistenceStore) GetPublic(secretId string) ([]byte, error) {
+	var path string
+
+	path = secrets.SecretPath + secretId
+	return ioutil.ReadFile(path)
+}
+
+func (f *filePersistenceStore) GetSecretData(
+	secretId string,
+	plain []byte,
+) (map[string]interface{}, error) {
+	return nil, ErrInvalidRequest
+}
+
+func (f *filePersistenceStore) Set(
+	secretId string,
+	cipher []byte,
+	plain []byte,
+	secretData map[string]interface{},
+) error {
+	if secretData != nil {
+		return ErrInvalidRequest
+	}
+
+	path := secrets.SecretPath + secretId
+	os.MkdirAll(secrets.SecretPath, 0700)
+	file, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	_, err = file.Write(cipher)
+	return err
+}
+
+func (f *filePersistenceStore) Exists(secretId string) (bool, error) {
+	path := secrets.SecretPath + secretId
+	if checkValidPath(path) {
+		return true, nil
+	}
+	return false, nil
+}
+
+func (f *filePersistenceStore) Name() string {
+	return filePersistenceStoreName
+}
+
+func checkValidPath(path string) bool {
+	if _, err := os.Stat(path); err == nil {
+		return true
+	}
+	return false
+
+}

--- a/pkg/store/store_file.go
+++ b/pkg/store/store_file.go
@@ -14,7 +14,7 @@ const (
 
 var (
 	// ErrInvalidRequest is returned when a request to get/put SecretData is made without configuring KVDB as a persistence store.
-	ErrInvalidRequest = errors.New("Storing secret data is supported in AWS KMS only if provided with kvdb as persistence store.")
+	ErrInvalidRequest = errors.New("Storing secret data is supported in Secrets only if provided with kvdb as persistence store.")
 )
 
 func NewFilePersistenceStore() PersistenceStore {

--- a/pkg/store/store_kvdb.go
+++ b/pkg/store/store_kvdb.go
@@ -1,0 +1,189 @@
+package store
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+
+	"github.com/portworx/kvdb"
+)
+
+const (
+	kvdbPersistenceStoreName = "kvdbPersistenceStore"
+)
+
+func NewKvdbPersistenceStore(
+	kv kvdb.Kvdb,
+	publicBasePath string,
+	dataBasePath string,
+) PersistenceStore {
+	return &kvdbPersistenceStore{
+		kv,
+		publicBasePath,
+		dataBasePath,
+	}
+}
+
+type kvdbPersistenceStore struct {
+	kv                 kvdb.Kvdb
+	kvdbPublicBasePath string
+	kvdbDataBasePath   string
+}
+
+func (k *kvdbPersistenceStore) GetPublic(secretId string) ([]byte, error) {
+	key := k.kvdbPublicBasePath + secretId
+
+	// Get the public cipher
+	kvp, err := k.kv.Get(key)
+	if err != nil {
+		return nil, err
+	}
+	decodedCipherBlob, err := base64.StdEncoding.DecodeString(string(kvp.Value))
+	if err != nil {
+		return nil, err
+	}
+	return decodedCipherBlob, nil
+}
+
+func (k *kvdbPersistenceStore) GetSecretData(
+	secretId string,
+	plain []byte,
+) (map[string]interface{}, error) {
+	dataKey := k.kvdbDataBasePath + secretId
+
+	// Check if there exists a key
+	kvp, err := k.kv.Get(dataKey)
+	if err == kvdb.ErrNotFound {
+		return nil, nil
+	} else if err != nil {
+		return nil, err
+	}
+
+	// base4 decode the encrypted data stored in kvdb.
+	decodedEncryptedData, err := base64.StdEncoding.DecodeString(string(kvp.Value))
+	if err != nil {
+		return nil, err
+	}
+
+	// decrypt the encrypted data.
+	decryptedData, err := decrypt(decodedEncryptedData, plain)
+	if err != nil {
+		return nil, fmt.Errorf("Unable to decrypt secret data: %v", err)
+	}
+
+	secretData := make(map[string]interface{})
+	// unmarshal the data into a map
+	err = json.Unmarshal(decryptedData, &secretData)
+	if err != nil {
+		return nil, fmt.Errorf("Unable to unmarshal decrypted secret data: %v", err)
+	}
+	return secretData, nil
+}
+
+func (k *kvdbPersistenceStore) Set(
+	secretId string,
+	cipher []byte,
+	plain []byte,
+	secretData map[string]interface{},
+) error {
+	key := k.kvdbPublicBasePath + secretId
+	encodeCipher := base64.StdEncoding.EncodeToString(cipher)
+	// Save the public cipher
+	_, err := k.kv.Put(key, encodeCipher, 0)
+	if err != nil {
+		return err
+	}
+
+	// If no secretData is provided no need to store it.
+	if secretData == nil {
+		return nil
+	}
+
+	// marshal the input map into a byte array
+	data, err := json.Marshal(&secretData)
+	if err != nil {
+		return err
+	}
+
+	// Use the plaintext cipher to encrypt the
+	// marshalled secretData
+	encryptedData, err := encrypt(data, plain)
+	if err != nil {
+		return err
+	}
+
+	// encode the encrypted data and store it in kvdb
+	encodedEncryptedData := base64.StdEncoding.EncodeToString(encryptedData)
+
+	dataKey := k.kvdbDataBasePath + secretId
+	_, err = k.kv.Put(dataKey, encodedEncryptedData, 0)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (k *kvdbPersistenceStore) Exists(secretId string) (bool, error) {
+	key := k.kvdbPublicBasePath + secretId
+	_, err := k.kv.Get(key)
+	if err == nil {
+		return true, nil
+	} else if err == kvdb.ErrNotFound {
+		return false, nil
+	}
+	return false, err
+}
+
+func (k *kvdbPersistenceStore) Name() string {
+	return kvdbPersistenceStoreName
+}
+
+// encrypt encrypts the data using the passphrase
+func encrypt(data, passphrase []byte) ([]byte, error) {
+	gcm, err := getGCM(passphrase)
+	if err != nil {
+		return nil, err
+	}
+
+	nonce := make([]byte, gcm.NonceSize())
+
+	if _, err = io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, err
+	}
+
+	return gcm.Seal(nonce, nonce, data, nil), nil
+}
+
+// decrypt decrypts the cipherData using the passphrase
+func decrypt(cipherData, passphrase []byte) ([]byte, error) {
+	gcm, err := getGCM(passphrase)
+	if err != nil {
+		return nil, err
+	}
+
+	nonceSize := gcm.NonceSize()
+
+	if len(cipherData) < nonceSize {
+		return nil, errors.New("ciphertext too short")
+	}
+
+	nonce, cipherData := cipherData[:nonceSize], cipherData[nonceSize:]
+	decryptedData, err := gcm.Open(cipherData[:0], nonce, cipherData, nil)
+	return decryptedData, err
+}
+
+// getGCM returns golang's AEAD, a cipher mode for AES encryption
+// using Galois/Counter Mode (GCM)
+func getGCM(passphrase []byte) (cipher.AEAD, error) {
+	c, err := aes.NewCipher(passphrase)
+	if err != nil {
+		return nil, err
+	}
+
+	return cipher.NewGCM(c)
+}


### PR DESCRIPTION
The changes are divided into 3 commits

Commit 1:
The IBM implementation of the Secrets interface. 

Commit 2:
Adds a new pkg called IBM. This is a golang REST client for the Key Protect Service. This is a pkg provided by IBM and will move to vendor soon.

Commit 3:
Move the persistenceStore interface from AWS KMS to its own package so that IBM Key Protect implementation of Secrets can also use it.