### PR TITLE
Add a new API DeleteSecret to all the secret providers.

### DIFF
--- a/aws/aws_kms.go
+++ b/aws/aws_kms.go
@@ -55,7 +55,7 @@ type awsKmsSecrets struct {
 	sess   *session.Session
 	cmk    string
 	asc    sc.AWSCredentials
-	ps     persistenceStore
+	ps     store.PersistenceStore
 }
 
 func New(
@@ -64,7 +64,7 @@ func New(
 	if secretConfig == nil {
 		return nil, ErrCMKNotProvided
 	}
-	var ps persistenceStore
+	var ps store.PersistenceStore
 
 	v, _ := secretConfig[AwsCMKey]
 	cmk, _ := v.(string)
@@ -154,7 +154,7 @@ func (a *awsKmsSecrets) GetSecret(
 	}
 
 	// filePersistenceStore does not support storing of secretData
-	if a.ps.name() == filePersistenceStoreName {
+	if a.ps.Name() == store.FilePersistenceStoreName {
 		goto return_plaintext
 	}
 
@@ -197,6 +197,13 @@ func (a *awsKmsSecrets) PutSecret(
 		output.Plaintext,
 		secretData,
 	)
+}
+
+func (a *awsKmsSecrets) DeleteSecret(
+	secretId string,
+	keyContext map[string]string,
+) error {
+	return a.ps.Delete(secretId)
 }
 
 func (a *awsKmsSecrets) Encrypt(

--- a/dcos/dcos.go
+++ b/dcos/dcos.go
@@ -142,6 +142,13 @@ func (d *dcosSecrets) PutSecret(
 	return d.client.CreateOrUpdateSecret(keyContext[KeySecretStore], secretPath, secret)
 }
 
+func (d *dcosSecrets) DeleteSecret(
+	secretPath string,
+	keyContext map[string]string,
+) error {
+	return d.client.DeleteSecret(keyContext[KeySecretStore], secretPath)
+}
+
 func (d *dcosSecrets) Encrypt(
 	secretID string,
 	plainTextData string,

--- a/dcos/dcos_integration_test.go
+++ b/dcos/dcos_integration_test.go
@@ -85,5 +85,17 @@ func (d *dcosSecretTest) TestGetSecret(t *testing.T) error {
 }
 
 func (d *dcosSecretTest) TestDeleteSecret(t *testing.T) error {
+	// Delete of a key that exists should succeed
+	err := d.s.DeleteSecret("osd/test/secret_with_default_store", nil)
+	assert.NoError(t, err, "Unexpected error on DeleteSecret")
+
+	// Get of a deleted key should fail
+	_, err = d.s.GetSecret("osd/test/secret_with_default_store", nil)
+	assert.EqualError(t, secrets.ErrInvalidSecretId, err.Error(), "Expected an error on GetSecret after the key is deleted")
+
+	// Delete of a non-existent key should also succeed
+	err = d.s.DeleteSecret("dummy", nil)
+	assert.NoError(t, err, "Unepxected error on DeleteSecret")
 	return nil
+
 }

--- a/dcos/dcos_integration_test.go
+++ b/dcos/dcos_integration_test.go
@@ -30,8 +30,9 @@ func TestAll(t *testing.T) {
 	secretConfig[KeyDcosURL] = os.Getenv("DCOS_SECRETS_TEST_CLUSTER_URL")
 
 	ds, err := NewDCOSSecretTest(secretConfig)
-
-	assert.Nil(t, err)
+	if err != nil {
+		t.Fatalf("Unable to create a dcos secrets client: %v", err)
+	}
 
 	test.Run(ds, t)
 }
@@ -80,5 +81,9 @@ func (d *dcosSecretTest) TestGetSecret(t *testing.T) error {
 	assert.Equal(t, "bar", secretData["foo"])
 	assert.Equal(t, float64(10), secretData["count"])
 
+	return nil
+}
+
+func (d *dcosSecretTest) TestDeleteSecret(t *testing.T) error {
 	return nil
 }

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -61,6 +61,13 @@ func (v *dockerSecrets) PutSecret(
 	return secrets.ErrNotSupported
 }
 
+func (v *dockerSecrets) DeleteSecret(
+	secretId string,
+	keyContext map[string]string,
+) error {
+	return secrets.ErrNotSupported
+}
+
 func (v *dockerSecrets) Encrypt(
 	secretId string,
 	plaintTextData string,

--- a/docker/docker_test.go
+++ b/docker/docker_test.go
@@ -60,3 +60,7 @@ func (d *dockerSecretTest) TestGetSecret(t *testing.T) error {
 
 	return nil
 }
+
+func (d *dockerSecretTest) TestDeleteSecret(t *testing.T) error {
+	return nil
+}

--- a/ibm/README.md
+++ b/ibm/README.md
@@ -4,5 +4,5 @@
 3. Get the Service API Key and the Instance ID using the steps describe under pkg/ibm/README.md
 
 ```
-$ IBM_SERVICE_API_KEY=<api_key> IBM_INSTANCE_ID=<instance_id> IBM_CUSTOMER_ROOT_KEY=<crk>
+$ IBM_SERVICE_API_KEY=<api_key> IBM_INSTANCE_ID=<instance_id> IBM_CUSTOMER_ROOT_KEY=<crk> go test -v .
 ```

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -1,0 +1,13 @@
+Kubernetes Secrets Provider
+
+To run the test export the following environment variable
+
+```
+$ export KUBECONFIG=/path/to/kubeconfig/file
+```
+
+Run the go test
+
+```
+$ go test -v .
+```

--- a/k8s/k8s.go
+++ b/k8s/k8s.go
@@ -77,6 +77,18 @@ func (s *k8sSecrets) PutSecret(
 	return err
 }
 
+func (s *k8sSecrets) DeleteSecret(
+	secretName string,
+	keyContext map[string]string,
+) error {
+	namespace, exists := keyContext[SecretNamespace]
+	if !exists {
+		return fmt.Errorf("Namespace cannot be empty.")
+	}
+
+	return k8s.Instance().DeleteSecret(secretName, namespace)
+}
+
 func (s *k8sSecrets) Encrypt(
 	secretId string,
 	plaintTextData string,

--- a/k8s/k8s_test.go
+++ b/k8s/k8s_test.go
@@ -1,11 +1,19 @@
 package k8s
 
 import (
-	"io/ioutil"
 	"testing"
+	"time"
 
 	"github.com/libopenstorage/secrets"
 	"github.com/libopenstorage/secrets/test"
+	"github.com/pborman/uuid"
+	"github.com/portworx/sched-ops/k8s"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	secretName = "openstorage-secret-test"
+	secretId   = "mysql-username"
 )
 
 func TestAll(t *testing.T) {
@@ -14,11 +22,20 @@ func TestAll(t *testing.T) {
 		t.Fatalf("Unable to create a Kubernetes Secret instance: %v", err)
 		return
 	}
+	// The secret needs to be created before running the tests
+	data := make(map[string][]byte)
+	data[secretId] = []byte("passphrase")
+	_, err = k8s.Instance().UpdateSecretData(secretName, "default", data)
+	if err != nil {
+		t.Fatalf("Failed to get secret for test: %v", err)
+		return
+	}
 	test.Run(ks, t)
 }
 
 type k8sSecretTest struct {
-	s secrets.Secrets
+	s          secrets.Secrets
+	passphrase string
 }
 
 func NewK8sSecretTest(secretConfig map[string]interface{}) (test.SecretTest, error) {
@@ -26,37 +43,59 @@ func NewK8sSecretTest(secretConfig map[string]interface{}) (test.SecretTest, err
 	if err != nil {
 		return nil, err
 	}
-	return &k8sSecretTest{s}, nil
+	return &k8sSecretTest{s, ""}, nil
 }
 
-// PutSecret is not yet implemented
 func (k *k8sSecretTest) TestPutSecret(t *testing.T) error {
+	secretData := make(map[string]interface{})
+	k.passphrase = uuid.New()
+	secretData[secretId] = k.passphrase
+	// PutSecret with non-nil secretData and no namespace should fail
+	err := k.s.PutSecret(secretName, secretData, nil)
+	assert.Error(t, err, "Expected an error on PutSecret")
+
+	keyContext := make(map[string]string)
+	keyContext[SecretNamespace] = "default"
+	// PutSecret with already existing secretId
+	err = k.s.PutSecret(secretName, secretData, keyContext)
+	assert.NoError(t, err, "Unexpected error on PutSecret")
 	return nil
 }
 
 func (k *k8sSecretTest) TestGetSecret(t *testing.T) error {
-	secretId := "mysql_username"
-	cipherBlob := []byte{116, 101, 115, 116}
-	err := ioutil.WriteFile(getSecretKey(secretId), cipherBlob, 0644)
-	if err != nil {
-		t.Errorf("Unexpected error: %v", err)
-	}
+	secretData, err := k.s.GetSecret(secretName, nil)
+	assert.Error(t, err, "Expected an error when no namespace is provided")
+	assert.Nil(t, secretData, "Expected empty secret data")
 
-	secretData, err := k.s.GetSecret(secretId, nil)
-	if err != nil {
-		t.Errorf("Unexpected error in GetSecret: %v", err)
-	}
-	if len(secretData) == 0 {
-		t.Errorf("GetSecret returned invalid data.")
-	}
-	secretBlob, ok := secretData[secretId]
-	if !ok {
-		t.Errorf("GetSecret returned invalid data")
-	}
+	keyContext := make(map[string]string)
+	keyContext[SecretNamespace] = "default"
 
-	if len(secretBlob.([]byte)) != len(cipherBlob) {
-		t.Errorf("Cipher texts do not match")
-	}
+	plainText1, err := k.s.GetSecret(secretName, keyContext)
+	assert.NoError(t, err, "Expected no error on GetSecret")
+	// We have got secretData
+	assert.NotNil(t, plainText1, "Invalid plainText was returned")
+	v, ok := plainText1[secretId]
+	assert.True(t, ok, "Unexpected plainText")
+	str, ok := v.(string)
+	assert.True(t, ok, "Unexpected plainText")
+	assert.Equal(t, k.passphrase, str, "Unexpected passphrase")
 
+	return nil
+}
+
+func (k *k8sSecretTest) TestDeleteSecret(t *testing.T) error {
+	err := k.s.DeleteSecret(secretName, nil)
+	assert.Error(t, err, "Expected an error when no namespace is provided")
+
+	keyContext := make(map[string]string)
+	keyContext[SecretNamespace] = "default"
+
+	err = k.s.DeleteSecret(secretName, keyContext)
+	assert.NoError(t, err, "Unexpected an error on Delete")
+
+	// Get of a deleted secret should fail. Sleeping for the delete to finish
+	time.Sleep(2 * time.Second)
+	_, err = k.s.GetSecret(secretName, keyContext)
+	assert.Error(t, err, "Expected error on GetSecret")
 	return nil
 }

--- a/kvdb/kvdb.go
+++ b/kvdb/kvdb.go
@@ -60,6 +60,14 @@ func (v *kvdbSecrets) PutSecret(
 	return err
 }
 
+func (v *kvdbSecrets) DeleteSecret(
+	secretId string,
+	keyContext map[string]string,
+) error {
+	_, err := v.client.Delete(SecretKey + secretId)
+	return err
+}
+
 func (v *kvdbSecrets) Encrypt(
 	encryptedKeyId string,
 	plaintTextData string,

--- a/kvdb/kvdb_test.go
+++ b/kvdb/kvdb_test.go
@@ -3,16 +3,15 @@ package kvdb
 import (
 	"testing"
 
+	"github.com/libopenstorage/secrets/test"
 	"github.com/portworx/kvdb"
 	e2 "github.com/portworx/kvdb/etcd/v2"
-	"github.com/libopenstorage/secrets/test"
 )
 
 func TestAll(t *testing.T) {
 	config := make(map[string]interface{})
-	
+
 	kv, _ := kvdb.New(e2.Name, "pwx/", []string{"http://127.0.0.1:2379"}, nil, nil)
 	config[KvdbKey] = kv
 	test.Run(New, config, t)
 }
-

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -17,6 +17,10 @@ type PersistenceStore interface {
 	// for the given secretId
 	Set(secretId string, cipher, plain []byte, secretData map[string]interface{}) error
 
+	// Delete deletes the kms public info and the encrypted secretData if any
+	// for the given secretId
+	Delete(secretId string) error
+
 	// Name returns the name of persistence store
 	Name() string
 }

--- a/pkg/store/store_file.go
+++ b/pkg/store/store_file.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	filePersistenceStoreName = "filePersistenceStore"
+	FilePersistenceStoreName = "filePersistenceStore"
 )
 
 var (
@@ -65,8 +65,17 @@ func (f *filePersistenceStore) Exists(secretId string) (bool, error) {
 	return false, nil
 }
 
+func (f *filePersistenceStore) Delete(secretId string) error {
+	path := secrets.SecretPath + secretId
+	exists, _ := f.Exists(secretId)
+	if !exists {
+		return nil
+	}
+	return os.Remove(path)
+}
+
 func (f *filePersistenceStore) Name() string {
-	return filePersistenceStoreName
+	return FilePersistenceStoreName
 }
 
 func checkValidPath(path string) bool {

--- a/pkg/store/store_kvdb.go
+++ b/pkg/store/store_kvdb.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	kvdbPersistenceStoreName = "kvdbPersistenceStore"
+	KvdbPersistenceStoreName = "kvdbPersistenceStore"
 )
 
 func NewKvdbPersistenceStore(
@@ -139,8 +139,17 @@ func (k *kvdbPersistenceStore) Exists(secretId string) (bool, error) {
 	return false, err
 }
 
+func (k *kvdbPersistenceStore) Delete(secretId string) error {
+	key := k.kvdbPublicBasePath + secretId
+	_, err := k.kv.Delete(key)
+	if err == nil || err == kvdb.ErrNotFound {
+		return nil
+	}
+	return err
+}
+
 func (k *kvdbPersistenceStore) Name() string {
-	return kvdbPersistenceStoreName
+	return KvdbPersistenceStoreName
 }
 
 // encrypt encrypts the data using the passphrase

--- a/secrets.go
+++ b/secrets.go
@@ -43,6 +43,13 @@ type Secrets interface {
 		keyContext map[string]string,
 	) error
 
+	// DeleteSecret deletes the secret data associated with the
+	// supplied secretId.
+	DeleteSecret(
+		secretId string,
+		keyContext map[string]string,
+	) error
+
 	// Encrypt encrypts the supplied plain text data using the given key.
 	// The API would fetch the plain text key, encrypt the data with it.
 	// The plain text key will not be stored anywhere else and would be

--- a/test/secrets.go
+++ b/test/secrets.go
@@ -7,9 +7,11 @@ import (
 type SecretTest interface {
 	TestPutSecret(t *testing.T) error
 	TestGetSecret(t *testing.T) error
+	TestDeleteSecret(t *testing.T) error
 }
 
 func Run(st SecretTest, t *testing.T) {
 	st.TestPutSecret(t)
 	st.TestGetSecret(t)
+	st.TestDeleteSecret(t)
 }

--- a/vault/vault.go
+++ b/vault/vault.go
@@ -148,6 +148,14 @@ func (v *vaultSecrets) PutSecret(
 	return err
 }
 
+func (v *vaultSecrets) DeleteSecret(
+	secretID string,
+	keyContext map[string]string,
+) error {
+	_, err := v.client.Logical().Delete(v.getSecretKey(secretID))
+	return err
+}
+
 func (v *vaultSecrets) Encrypt(
 	secretID string,
 	plaintTextData string,

--- a/vault/vault_integration_test.go
+++ b/vault/vault_integration_test.go
@@ -76,10 +76,20 @@ func (v *vaultSecretTest) TestPutSecret(t *testing.T) error {
 	if err == nil {
 		t.Fatalf("Expected error when no secret key present")
 	}
+
+	err = v.s.DeleteSecret(keyId, nil)
+	if err != nil {
+		t.Fatalf("Unable to delete key: %v %v", keyId, err)
+	}
 	return nil
 }
 
 func (v *vaultSecretTest) TestGetSecret(t *testing.T) error {
 	// TestPutSecret does get testing as well
+	return nil
+}
+
+func (v *vaultSecretTest) TestDeleteSecret(t *testing.T) error {
+	// TestPutSecret does delete testing as well
 	return nil
 }

--- a/vault/vault_integration_test.go
+++ b/vault/vault_integration_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/libopenstorage/secrets"
 	"github.com/libopenstorage/secrets/test"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestAllWithDefaultBackend(t *testing.T) {
@@ -56,31 +57,21 @@ func (v *vaultSecretTest) TestPutSecret(t *testing.T) error {
 		t.Fatalf("secrets is nil")
 	}
 	err := v.s.PutSecret(keyId, data, nil)
-	if err != nil {
-		t.Fatalf("Unable to put key into secrets: %v", err)
-	}
+	assert.NoError(t, err, "Unable to put key into secrets.")
 
 	plainText, err := v.s.GetSecret(keyId, nil)
-	if err != nil {
-		t.Fatalf("Unable to get key from secrets: %v", err)
-	}
-	if len(data) != len(plainText) {
-		t.Errorf("Put and Get keys do not match")
-	}
+	assert.NoError(t, err, "Unable to get key from secrets")
+	assert.Equal(t, len(data), len(plainText), "Put and Get keys do not match")
 	for k, v := range plainText {
-		if o, exists := data[k]; !exists || o != v {
-			t.Errorf("Put and Get values do not match")
-		}
+		o, exists := data[k]
+		assert.True(t, exists, "Put and Get values do not match")
+		assert.Equal(t, o, v, "Put and Get values do not match")
 	}
 	_, err = v.s.GetSecret("unknown_key", nil)
-	if err == nil {
-		t.Fatalf("Expected error when no secret key present")
-	}
+	assert.Error(t, err, "Expected error when no secret key present")
 
 	err = v.s.DeleteSecret(keyId, nil)
-	if err != nil {
-		t.Fatalf("Unable to delete key: %v %v", keyId, err)
-	}
+	assert.NoError(t, err, "Expected no error on delete secret")
 	return nil
 }
 


### PR DESCRIPTION
- For IBM KeyProtect, if the secretData is not provided in PutSecret then
  use the WrapCreateDEK API which will create the passphrase.
- Fix the kvdband file persistence stores


Modify UTs for all providers 
- Add a UT for DeleteSecret for all the providers which support Delete
- Use assert for all the tests.
