### PR TITLE
IBM: Add support to add references in persistence store to specific keys

### DIFF
--- a/secrets.go
+++ b/secrets.go
@@ -19,9 +19,17 @@ var (
 
 const (
 	SecretPath = "/var/lib/osd/secrets/"
+	// CustomSecretData is a constant used in the key context of the secrets APIs
+	// It indicates that the secret provider should not generate secret but use the provided secret
+	// in the API
+	CustomSecretData = "custom_secret_data"
+	// PublicSecretData is a constant used in the key context of Secret APIs
+	// It indicates that the API is dealing with the public part of a secret instead
+	// of the actual secret
+	PublicSecretData = "public_secret_data"
 )
 
-// Secrets interface implemented by backed Key Management Systems (KMS)
+// Secrets interface implemented by backend Key Management Systems (KMS)
 type Secrets interface {
 	// String representation of the backend KMS
 	String() string


### PR DESCRIPTION

Add a new keycontext flag SecretReferenceKey to indicate in PutSecret that
a new secret does not need to be created but only a reference to the existing secret
with a new name needs to be added in the persistence store.