### PR TITLE
Azure Key vault support

### DIFF
--- a/azure/azure_kv.go
+++ b/azure/azure_kv.go
@@ -84,6 +84,9 @@ func (az *azureSecrets) GetSecret(
 	ctx, cancel := context.WithTimeout(context.Background(), 6000*time.Second)
 	defer cancel()
 
+	if secretID == "" {
+		return nil, secrets.ErrEmptySecretId
+	}
 	secretResp, err := az.kv.GetSecret(ctx, az.baseURL, secretID, "")
 	if err != nil {
 		return nil, err
@@ -101,6 +104,13 @@ func (az *azureSecrets) PutSecret(
 ) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 6000*time.Second)
 	defer cancel()
+
+	if secretName == "" {
+		return secrets.ErrEmptySecretId
+	}
+	if len(secretData) == 0 {
+		return secrets.ErrEmptySecretData
+	}
 	_, err := az.kv.SetSecret(ctx, az.baseURL, secretName, keyvault.SecretSetParameters{
 		Value: to.StringPtr(secretData[secretName].(string)),
 	})
@@ -116,6 +126,9 @@ func (az *azureSecrets) DeleteSecret(
 	ctx, cancel := context.WithTimeout(context.Background(), 6000*time.Second)
 	defer cancel()
 
+	if secretName == "" {
+		return secrets.ErrEmptySecretId
+	}
 	_, err := az.kv.DeleteSecret(ctx, az.baseURL, secretName)
 	if err != nil {
 		return err

--- a/azure/azure_kv.go
+++ b/azure/azure_kv.go
@@ -1,0 +1,193 @@
+package azure
+
+import (
+	"context"
+	"errors"
+	"net/url"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/services/keyvault/2016-10-01/keyvault"
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/adal"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/libopenstorage/secrets"
+)
+
+const (
+	Name       = "AzureKV"
+	AzureCloud = "AzurePublicCloud"
+)
+
+var (
+	ErrAzureTenantIDNotSet   = errors.New("AZURE_TENANT_ID not set.")
+	ErrAzureClientIDNotSet   = errors.New("AZURE_CLIENT_ID not set.")
+	ErrAzureSecretIDNotSet   = errors.New("AZURE_SECRET_ID not set.")
+	ErrAzureVaultURLNotSet   = errors.New("AZURE_VAULT_URL not set.")
+	ErrAzureEnviromentNotset = errors.New("AZURE_ENVIORMENT not set.")
+	ErrAzureConfigMissing    = errors.New("AzureConfig is not provided")
+	ErrAzureAuthentication   = errors.New("Azure authentication failed")
+)
+
+type azureSecrets struct {
+	kv      keyvault.BaseClient
+	baseURL string
+}
+
+func New(
+	secretConfig map[string]interface{},
+) (secrets.Secrets, error) {
+	if len(secretConfig) == 0 {
+		return nil, ErrAzureConfigMissing
+	}
+	tenantID := getAzureKVParams(secretConfig, "AZURE_TENANT_ID")
+	if tenantID == "" {
+		return nil, ErrAzureTenantIDNotSet
+	}
+	clientID := getAzureKVParams(secretConfig, "AZURE_CLIENT_ID")
+	if clientID == "" {
+		return nil, ErrAzureClientIDNotSet
+	}
+	secretID := getAzureKVParams(secretConfig, "AZURE_CLIENT_SECRET")
+	if secretID == "" {
+		return nil, ErrAzureSecretIDNotSet
+	}
+	envName := getAzureKVParams(secretConfig, "AZURE_ENVIORNMENT")
+	if envName == "" {
+		//	return nil, ErrAzureEnviromentNotset
+		envName = AzureCloud
+	}
+	vaultURL := getAzureKVParams(secretConfig, "AZURE_VAULT_URL")
+	if vaultURL == "" {
+		return nil, ErrAzureVaultURLNotSet
+	}
+
+	client, err := getAzureVaultClient(clientID, secretID, tenantID, envName)
+	if err != nil {
+		return nil, ErrAzureAuthentication
+	}
+
+	return &azureSecrets{
+		kv:      client,
+		baseURL: vaultURL,
+	}, nil
+}
+
+func (az *azureSecrets) GetSecret(
+	secretID string,
+	keyContext map[string]string,
+) (map[string]interface{}, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 6000*time.Second)
+	defer cancel()
+
+	// TODO: check if version param is mandetory
+	// right now its work if we don't provide secret version
+	secretResp, err := az.kv.GetSecret(ctx, az.baseURL, secretID, "")
+	if err != nil {
+		return nil, err
+	}
+	secretData := make(map[string]interface{})
+	secretData[secretID] = *secretResp.Value
+
+	return secretData, nil
+}
+
+func (az *azureSecrets) PutSecret(
+	secretName string,
+	secretData map[string]interface{},
+	keyContext map[string]string,
+) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 6000*time.Second)
+	defer cancel()
+	// should call update here
+	_, err := az.kv.SetSecret(ctx, az.baseURL, secretName, keyvault.SecretSetParameters{
+		Value: to.StringPtr(secretData[secretName].(string)),
+	})
+	if err != nil {
+		return err
+	}
+	return nil
+}
+func (az *azureSecrets) DeleteSecret(
+	secretName string,
+	keyContext map[string]string,
+) error {
+	return nil
+}
+
+func (az *azureSecrets) ListSecrets() ([]string, error) {
+	return nil, secrets.ErrNotSupported
+}
+
+func (az *azureSecrets) Encrypt(
+	secretId string,
+	plaintTextData string,
+	keyContext map[string]string,
+) (string, error) {
+	return "", secrets.ErrNotSupported
+}
+
+func (az *azureSecrets) Decrypt(
+	secretId string,
+	encryptedData string,
+	keyContext map[string]string,
+) (string, error) {
+	return "", secrets.ErrNotSupported
+}
+
+func (az *azureSecrets) Rencrypt(
+	originalSecretId string,
+	newSecretId string,
+	originalKeyContext map[string]string,
+	newKeyContext map[string]string,
+	encryptedData string,
+) (string, error) {
+	return "", secrets.ErrNotSupported
+}
+
+func (az *azureSecrets) String() string {
+	return Name
+}
+
+func getAzureKVParams(secretConfig map[string]interface{}, name string) string {
+	if tokenIntf, exists := secretConfig[name]; exists {
+		return tokenIntf.(string)
+	} else {
+		return os.Getenv(name)
+	}
+}
+
+func getAzureVaultClient(clientID, secretID, tenantID, envName string) (keyvault.BaseClient, error) {
+	var environment *azure.Environment
+	alternateEndpoint, _ := url.Parse(
+		"https://login.windows.net/" + tenantID + "/oauth2/token")
+
+	keyClient := keyvault.New()
+	env, err := azure.EnvironmentFromName(envName)
+	if err != nil {
+		return keyClient, err
+	}
+	environment = &env
+	oauthconfig, err := adal.NewOAuthConfig(
+		environment.ActiveDirectoryEndpoint, tenantID)
+	if err != nil {
+		return keyClient, err
+	}
+	oauthconfig.AuthorizeEndpoint = *alternateEndpoint
+
+	token, err := adal.NewServicePrincipalToken(
+		*oauthconfig, clientID, secretID, strings.TrimSuffix(environment.KeyVaultEndpoint, "/"))
+	if err != nil {
+		return keyClient, err
+	}
+	keyClient.Authorizer = autorest.NewBearerAuthorizer(token)
+	return keyClient, nil
+}
+
+func init() {
+	if err := secrets.Register(Name, New); err != nil {
+		panic(err.Error())
+	}
+}

--- a/azure/azure_kv.go
+++ b/azure/azure_kv.go
@@ -13,6 +13,16 @@ import (
 const (
 	Name       = "AzureKV"
 	AzureCloud = "AzurePublicCloud"
+	// AzureTenantID for Azure Active Directory
+	AzureTenantID = "AZURE_TENANT_ID"
+	// AzureClientID of service principal account
+	AzureClientID = "AZURE_CLIENT_ID"
+	// AzureClientSecret of service principal account
+	AzureClientSecret = "AZURE_CLIENT_SECRET"
+	// AzureEnviornment to connect
+	AzureEnviornment = "AZURE_ENVIORNMENT"
+	// AzureVaultURI of azure key vault
+	AzureVaultURI = "AZURE_VAULT_URL"
 )
 
 var (

--- a/azure/azure_kv.go
+++ b/azure/azure_kv.go
@@ -26,7 +26,7 @@ const (
 	// AzureVaultURI of azure key vault
 	AzureVaultURL = "AZURE_VAULT_URL"
 	// Default context timeout for Azure SDK API's
-	defaultTimeout = 6000
+	defaultTimeout = 6000 * time.Second
 )
 
 var (
@@ -86,7 +86,7 @@ func (az *azureSecrets) GetSecret(
 	secretID string,
 	keyContext map[string]string,
 ) (map[string]interface{}, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
 	defer cancel()
 
 	if secretID == "" {
@@ -115,7 +115,7 @@ func (az *azureSecrets) PutSecret(
 	secretData map[string]interface{},
 	keyContext map[string]string,
 ) error {
-	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
 	defer cancel()
 
 	if secretName == "" {
@@ -139,7 +139,7 @@ func (az *azureSecrets) DeleteSecret(
 	secretName string,
 	keyContext map[string]string,
 ) error {
-	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
 	defer cancel()
 
 	if secretName == "" {

--- a/azure/azure_kv.go
+++ b/azure/azure_kv.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	Name       = "AzureKV"
+	Name       = "azure-kv"
 	AzureCloud = "AzurePublicCloud"
 	// AzureTenantID for Azure Active Directory
 	AzureTenantID = "AZURE_TENANT_ID"

--- a/azure/azure_kv_helper.go
+++ b/azure/azure_kv_helper.go
@@ -1,0 +1,47 @@
+package azure
+
+import (
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/services/keyvault/2016-10-01/keyvault"
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/adal"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+func getAzureKVParams(secretConfig map[string]interface{}, name string) string {
+	if tokenIntf, exists := secretConfig[name]; exists {
+		return tokenIntf.(string)
+	} else {
+		return os.Getenv(name)
+	}
+}
+
+func getAzureVaultClient(clientID, secretID, tenantID, envName string) (keyvault.BaseClient, error) {
+	var environment *azure.Environment
+	alternateEndpoint, _ := url.Parse(
+		"https://login.windows.net/" + tenantID + "/oauth2/token")
+
+	keyClient := keyvault.New()
+	env, err := azure.EnvironmentFromName(envName)
+	if err != nil {
+		return keyClient, err
+	}
+	environment = &env
+	oauthconfig, err := adal.NewOAuthConfig(
+		environment.ActiveDirectoryEndpoint, tenantID)
+	if err != nil {
+		return keyClient, err
+	}
+	oauthconfig.AuthorizeEndpoint = *alternateEndpoint
+
+	token, err := adal.NewServicePrincipalToken(
+		*oauthconfig, clientID, secretID, strings.TrimSuffix(environment.KeyVaultEndpoint, "/"))
+	if err != nil {
+		return keyClient, err
+	}
+	keyClient.Authorizer = autorest.NewBearerAuthorizer(token)
+	return keyClient, nil
+}

--- a/azure/azure_kv_test.go
+++ b/azure/azure_kv_test.go
@@ -1,0 +1,102 @@
+package azure
+
+import (
+	"testing"
+
+	"github.com/libopenstorage/secrets"
+	"github.com/libopenstorage/secrets/test"
+	"github.com/pborman/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	testkey    = "test-kv-key"
+	testsecret = "test-kv-secret"
+)
+
+type azureSecretsTest struct {
+	s secrets.Secrets
+}
+
+func TestAll(t *testing.T) {
+
+	config := make(map[string]interface{})
+	az, err := NewAzureKVSecretTest(config)
+	assert.Nil(t, err)
+	assert.NotNil(t, az)
+	test.Run(az, t)
+}
+
+func NewAzureKVSecretTest(secretConfig map[string]interface{}) (test.SecretTest, error) {
+	s, err := New(secretConfig)
+	if err != nil {
+		return nil, err
+	}
+	return &azureSecretsTest{s}, nil
+}
+
+func (a *azureSecretsTest) TestPutSecret(t *testing.T) error {
+	secretData := make(map[string]interface{})
+
+	secretData[testkey] = uuid.New()
+
+	// PutSecret should be successfull
+	err := a.s.PutSecret(testkey, secretData, nil)
+	assert.Nil(t, err)
+
+	// Since azure allow to set multiple version of same secrets
+	// make sure you are getting same secret ID after resetting
+
+	secretData[testkey] = testsecret
+	err = a.s.PutSecret(testkey, secretData, nil)
+	assert.Nil(t, err)
+
+	resp, err := a.s.GetSecret(testkey, nil)
+	assert.Nil(t, err)
+	assert.NotNil(t, resp)
+	assert.Equal(t, resp[testkey].(string), testsecret)
+
+	// clean up
+	err = a.s.DeleteSecret(testkey, nil)
+	assert.Nil(t, err)
+
+	// try to get secret again, should return err
+	resp, err = a.s.GetSecret(testkey, nil)
+	assert.Error(t, err, "Expected secret to fail for non-existant key")
+
+	return nil
+}
+
+func (a *azureSecretsTest) TestGetSecret(t *testing.T) error {
+	// GetSecret with non-existant id
+	_, err := a.s.GetSecret("dummy", nil)
+	assert.Error(t, err, "Expected GetSecret to fail")
+
+	secretData := make(map[string]interface{})
+	secretData[testkey] = testsecret
+	err = a.s.PutSecret(testkey, secretData, nil)
+	assert.Nil(t, err)
+
+	resp, err := a.s.GetSecret(testkey, nil)
+	assert.Nil(t, err)
+	assert.NotNil(t, resp)
+	assert.Equal(t, resp[testkey].(string), testsecret)
+
+	// clean up
+	err = a.s.DeleteSecret(testkey, nil)
+	assert.Nil(t, err)
+
+	return nil
+}
+
+func (a *azureSecretsTest) TestDeleteSecret(t *testing.T) error {
+	// Already Tested in PutSecret And GetSecret tests
+	return nil
+}
+
+func (a *azureSecretsTest) TestListSecrets(t *testing.T) error {
+	ids, err := a.s.ListSecrets()
+	assert.Error(t, secrets.ErrNotSupported, err.Error(), "ListSecrets is not supported for azure KV")
+	assert.Nil(t, ids, "Ids is expected to be nil")
+	return nil
+}

--- a/azure/azure_kv_test.go
+++ b/azure/azure_kv_test.go
@@ -37,11 +37,15 @@ func NewAzureKVSecretTest(secretConfig map[string]interface{}) (test.SecretTest,
 
 func (a *azureSecretsTest) TestPutSecret(t *testing.T) error {
 	secretData := make(map[string]interface{})
+	// PutSecret should be successfull
+	err := a.s.PutSecret(testkey, secretData, nil)
+	assert.NotNil(t, err)
+	assert.Contains(t, err.Error(), "Secret data cannot be empty", "Unexpected error on PutSecret")
 
 	secretData[testkey] = uuid.New()
 
 	// PutSecret should be successfull
-	err := a.s.PutSecret(testkey, secretData, nil)
+	err = a.s.PutSecret(testkey, secretData, nil)
 	assert.Nil(t, err)
 
 	// Since azure allow to set multiple version of same secrets
@@ -71,6 +75,9 @@ func (a *azureSecretsTest) TestGetSecret(t *testing.T) error {
 	// GetSecret with non-existant id
 	_, err := a.s.GetSecret("dummy", nil)
 	assert.Error(t, err, "Expected GetSecret to fail")
+
+	_, err = a.s.GetSecret("", nil)
+	assert.Error(t, err, "Secret Name/ID cannot be empty")
 
 	secretData := make(map[string]interface{})
 	secretData[testkey] = testsecret

--- a/azure/azure_kv_test.go
+++ b/azure/azure_kv_test.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/libopenstorage/secrets"
 	"github.com/libopenstorage/secrets/test"
-	"github.com/pborman/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -42,7 +41,9 @@ func (a *azureSecretsTest) TestPutSecret(t *testing.T) error {
 	assert.NotNil(t, err)
 	assert.Contains(t, err.Error(), "Secret data cannot be empty", "Unexpected error on PutSecret")
 
-	secretData[testkey] = uuid.New()
+	secretData["testcred"] = "test-cred"
+	secretData["testval"] = 10
+	secretData["testzone"] = "azure--dummy"
 
 	// PutSecret should be successfull
 	err = a.s.PutSecret(testkey, secretData, nil)
@@ -58,7 +59,7 @@ func (a *azureSecretsTest) TestPutSecret(t *testing.T) error {
 	resp, err := a.s.GetSecret(testkey, nil)
 	assert.Nil(t, err)
 	assert.NotNil(t, resp)
-	assert.Equal(t, resp[testkey].(string), testsecret)
+	assert.Equal(t, resp["testcred"].(string), "test-cred")
 
 	// clean up
 	err = a.s.DeleteSecret(testkey, nil)
@@ -80,14 +81,17 @@ func (a *azureSecretsTest) TestGetSecret(t *testing.T) error {
 	assert.Error(t, err, "Secret Name/ID cannot be empty")
 
 	secretData := make(map[string]interface{})
-	secretData[testkey] = testsecret
+	secretData["testcred"] = "test-cred"
+	secretData["testval"] = 10
+	secretData["testzone"] = "azure--dummy"
+
 	err = a.s.PutSecret(testkey, secretData, nil)
 	assert.Nil(t, err)
 
 	resp, err := a.s.GetSecret(testkey, nil)
 	assert.Nil(t, err)
 	assert.NotNil(t, resp)
-	assert.Equal(t, resp[testkey].(string), testsecret)
+	assert.Equal(t, resp["testzone"].(string), "azure--dummy")
 
 	// clean up
 	err = a.s.DeleteSecret(testkey, nil)

--- a/secrets.go
+++ b/secrets.go
@@ -14,6 +14,8 @@ var (
 	ErrInvalidSecretId = errors.New("No Secret Data found for Secret ID")
 	// ErrEmptySecretData returned when no secret data is provided to store the secret
 	ErrEmptySecretData = errors.New("Secret data cannot be empty")
+	// ErrEmptySecretId returned when no secret Name/ID is provided to retrive secret data
+	ErrEmptySecretId = errors.New("Secret Name/ID cannot be empty")
 	// ErrSecretExists returned when a secret for the given secret id already exists
 	ErrSecretExists = errors.New("Secret Id already exists")
 	// ErrInvalidSecretData is returned when no secret data is found


### PR DESCRIPTION
This PR add support for azure key vault, operation supported currently now are - 
 GetSecret - Get secret with id from Azure KV
 PutSecret -  Put secret data into azure KV
 DeleteSecret - Delete secret with ID from Azure KV

To test -
1. Export following environment variable
AZURE_TENANT_ID - Azure active directory tenant ID
AZURE_CLIENT_ID - Azure application ID
AZURE_CLIENT_SECRET - Azure application Secret
AZURE_VAULT_URL - Azure key vault endpoint URL
AZURE_ENVIORNMENT 
**Note:** Application should have acl permission set for given vault URL. Permission needed -
**secrets - set/get/delete**
2. Run go test -v ./azure


 
