### PR TITLE
AWS KMS: Update the AWS KMS implementation to use PublicData in key contexts

### DIFF
--- a/aws/aws_kms.go
+++ b/aws/aws_kms.go
@@ -36,10 +36,6 @@ const (
 )
 
 var (
-	// ErrAwsAccessKeyNotSet is returned when AWS credential for ACCESS_KEY is not set
-	ErrAwsAccessKeyNotSet = errors.New("AWS_ACCESS_KEY_ID not set.")
-	// ErrAwsSecretAccessKeyNotSet is returned when AWS credential for SECRET_KEY is not set
-	ErrAwsSecretAccessKeyNotSet = errors.New("AWS_SECRET_ACCESS_KEY not set.")
 	// ErrCMKNotProvided is returned when CMK is not provided.
 	ErrCMKNotProvided = errors.New("AWS CMK not provided. Cannot perform KMS operations.")
 	// ErrAWSRegionNotProvided is returned when region is not provided.

--- a/aws/credentials/credentials.go
+++ b/aws/credentials/credentials.go
@@ -4,11 +4,11 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds"
-        "github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
+	"github.com/aws/aws-sdk-go/aws/session"
 )
 
 type AWSCredentials interface {
@@ -36,12 +36,12 @@ func NewAWSCredentials(id, secret, token string) (AWSCredentials, error) {
 		res, err := client.Get(url)
 		if err == nil {
 			sess := session.Must(session.NewSession())
-                        ec2RoleProvider := &ec2rolecreds.EC2RoleProvider{
+			ec2RoleProvider := &ec2rolecreds.EC2RoleProvider{
 				Client: ec2metadata.New(sess, &aws.Config{
 					HTTPClient: &client,
-                                }),
-                        }
-                        providers = append(providers, ec2RoleProvider)
+				}),
+			}
+			providers = append(providers, ec2RoleProvider)
 			res.Body.Close()
 		}
 		providers = append(providers, &credentials.SharedCredentialsProvider{})


### PR DESCRIPTION

- If the PublicData key context is provided, then store only the cipher text
  in kvdb.
- Update the UTs