### PR TITLE
Use kvdb.Create instead of kvdb.Put in Store implementation of kvdb.

### DIFF
--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -14,7 +14,7 @@ type PersistenceStore interface {
 	Exists(secretId string) (bool, error)
 
 	// Set persists the kms public info and encyrpted secretData if provided
-	// for the given secretId
+	// for the given secretId. If the given secretId exists in the store it will return an error.
 	Set(secretId string, cipher, plain []byte, secretData map[string]interface{}) error
 
 	// Delete deletes the kms public info and the encrypted secretData if any

--- a/pkg/store/store_kvdb.go
+++ b/pkg/store/store_kvdb.go
@@ -95,8 +95,11 @@ func (k *kvdbPersistenceStore) Set(
 	key := k.kvdbPublicBasePath + secretId
 	encodeCipher := base64.StdEncoding.EncodeToString(cipher)
 	// Save the public cipher
-	_, err := k.kv.Put(key, encodeCipher, 0)
+	_, err := k.kv.Create(key, encodeCipher, 0)
 	if err != nil {
+		if err == kvdb.ErrExist {
+			return fmt.Errorf("secret with name %v already exists", secretId)
+		}
 		return err
 	}
 
@@ -122,8 +125,11 @@ func (k *kvdbPersistenceStore) Set(
 	encodedEncryptedData := base64.StdEncoding.EncodeToString(encryptedData)
 
 	dataKey := k.kvdbDataBasePath + secretId
-	_, err = k.kv.Put(dataKey, encodedEncryptedData, 0)
+	_, err = k.kv.Create(dataKey, encodedEncryptedData, 0)
 	if err != nil {
+		if err == kvdb.ErrExist {
+			return fmt.Errorf("secret with name %v already exists.", secretId)
+		}
 		return err
 	}
 	return nil


### PR DESCRIPTION
- This is to ensure that we do not overwrite the public or custom data stored
  in persistence store.