### PR TITLE
Add secret types constants to secrets base package

### DIFF
--- a/aws/aws_kms.go
+++ b/aws/aws_kms.go
@@ -18,7 +18,7 @@ import (
 
 const (
 	// Name of the secret store
-	Name = "aws-kms"
+	Name = secrets.TypeAWS
 	// AwsAccessKey corresponds to AWS credential AWS_ACCESS_KEY_ID
 	AwsAccessKey = "AWS_ACCESS_KEY_ID"
 	// AwsSecretAccessKey corresponds to AWS credential AWS_SECRET_ACCESS_KEY

--- a/azure/azure_kv.go
+++ b/azure/azure_kv.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	Name       = "azure-kv"
+	Name       = secrets.TypeAzure
 	AzureCloud = "AzurePublicCloud"
 	// AzureTenantID for Azure Active Directory
 	AzureTenantID = "AZURE_TENANT_ID"

--- a/dcos/dcos.go
+++ b/dcos/dcos.go
@@ -19,7 +19,7 @@ const (
 
 const (
 	// Name name of the secret provider
-	Name = "dcos"
+	Name = secrets.TypeDCOS
 	// KeySecretStore key used to set the secret store
 	KeySecretStore = "secret_store"
 )

--- a/docker/docker.go
+++ b/docker/docker.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	Name             = "docker"
+	Name             = secrets.TypeDocker
 	DockerSecretPath = "/run/secrets/"
 )
 

--- a/gcloud/gcloud_kms.go
+++ b/gcloud/gcloud_kms.go
@@ -22,7 +22,7 @@ import (
 
 const (
 	// Name of the secret store
-	Name = "gcloud-kms"
+	Name = secrets.TypeGCloud
 	// GoogleKmsResourceKey corresponds to the asymmetric resource id
 	GoogleKmsResourceKey = "GOOGLE_KMS_RESOURCE_ID"
 	// KMSKvdbkey is used to setup Google KMS Secret Store with kvdb for persistence

--- a/ibm/ibm_key_protect.go
+++ b/ibm/ibm_key_protect.go
@@ -18,7 +18,7 @@ import (
 
 const (
 	// Name of the secret store
-	Name = "ibm-kp"
+	Name = secrets.TypeIBM
 	// IbmServiceApiKey is the service ID API Key
 	IbmServiceApiKey = "IBM_SERVICE_API_KEY"
 	// IbmInstanceIdKey is the Key Protect Service's Instance ID

--- a/k8s/k8s.go
+++ b/k8s/k8s.go
@@ -8,7 +8,7 @@ import (
 )
 
 const (
-	Name            = "k8s"
+	Name            = secrets.TypeK8s
 	SecretNamespace = "namespace"
 )
 

--- a/kvdb/kvdb.go
+++ b/kvdb/kvdb.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	Name      = "kvdb"
+	Name      = secrets.TypeKVDB
 	KvdbKey   = "KVDB"
 	SecretKey = "secret/"
 )

--- a/secrets.go
+++ b/secrets.go
@@ -39,6 +39,18 @@ const (
 	OverwriteSecretDataInStore = "overwrite_secret_data_in_store"
 )
 
+const (
+	TypeAWS    = "aws-kms"
+	TypeAzure  = "azure-kv"
+	TypeDCOS   = "dcos"
+	TypeDocker = "docker"
+	TypeGCloud = "gcloud-kms"
+	TypeIBM    = "ibm-kp"
+	TypeK8s    = "k8s"
+	TypeKVDB   = "kvdb"
+	TypeVault  = "vault"
+)
+
 // Secrets interface implemented by backend Key Management Systems (KMS)
 type Secrets interface {
 	// String representation of the backend KMS

--- a/vault/vault.go
+++ b/vault/vault.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	Name                = "vault"
+	Name                = secrets.TypeVault
 	DefaultBackendPath  = "secret/"
 	VaultBackendPathKey = "VAULT_BACKEND_PATH"
 	vaultAddressPrefix  = "http"


### PR DESCRIPTION
This will allow us to switch between `lsecrets.Instance().String()` here:
https://github.com/libopenstorage/openstorage/blob/master/pkg/auth/secrets/secrets.go#L64

Instead of passing the secretsType into NewAuth.

Signed-off-by: Grant Griffiths <grant@portworx.com>