### PR TITLE
Add VAULT_BACKEND argument to Vault.

### DIFF
--- a/vault/vault.go
+++ b/vault/vault.go
@@ -15,9 +15,12 @@ const (
 	Name                = secrets.TypeVault
 	DefaultBackendPath  = "secret/"
 	VaultBackendPathKey = "VAULT_BACKEND_PATH"
+	VaultBackendKey     = "VAULT_BACKEND"
 	vaultAddressPrefix  = "http"
 	kvVersionKey        = "version"
 	kvDataKey           = "data"
+	kvVersion1          = "kv"
+	kvVersion2          = "kv-v2"
 )
 
 var (
@@ -85,17 +88,24 @@ func New(
 	} else {
 		backendPath = DefaultBackendPath
 	}
-
-	isKvV2, err := isKvV2(client, backendPath)
-	if err != nil {
-		return nil, err
+	var isBackendV2 bool
+	backend := getVaultParam(secretConfig, VaultBackendKey)
+	if backend == kvVersion1 {
+		isBackendV2 = false
+	} else if backend == kvVersion2 {
+		isBackendV2 = true
+	} else {
+		// TODO: Handle backends other than kv
+		isBackendV2, err = isKvV2(client, backendPath)
+		if err != nil {
+			return nil, err
+		}
 	}
-
 	return &vaultSecrets{
 		endpoint:      config.Address,
 		client:        client,
 		backendPath:   backendPath,
-		isKvBackendV2: isKvV2,
+		isKvBackendV2: isBackendV2,
 	}, nil
 }
 

--- a/vault/vault_test.go
+++ b/vault/vault_test.go
@@ -149,5 +149,51 @@ func TestNew(t *testing.T) {
 
 	assert.Nil(t, err)
 	assert.NotNil(t, client)
+
+	config = make(map[string]interface{})
+	config[api.EnvVaultAddress] = "http://127.0.0.1:8200"
+	config[api.EnvVaultToken] = "token"
+	config[VaultBackendKey] = "kv"
+	// Do not check backend version
+	backendVersionCheck := false
+	isKvV2 = func(*api.Client, string) (bool, error) {
+		backendVersionCheck = true
+		return true, nil
+	}
+	client, err = New(config)
+	assert.False(t, backendVersionCheck, "unexpected backend version check")
+	assert.Nil(t, err)
+	assert.NotNil(t, client)
+
+	config = make(map[string]interface{})
+	config[api.EnvVaultAddress] = "http://127.0.0.1:8200"
+	config[api.EnvVaultToken] = "token"
+	config[VaultBackendKey] = "kv-v2"
+	// Do not check backend version
+	backendVersionCheck = false
+	isKvV2 = func(*api.Client, string) (bool, error) {
+		backendVersionCheck = true
+		return true, nil
+	}
+	client, err = New(config)
+	assert.False(t, backendVersionCheck, "unexpected backend version check")
+	assert.Nil(t, err)
+	assert.NotNil(t, client)
+
+	config = make(map[string]interface{})
+	config[api.EnvVaultAddress] = "http://127.0.0.1:8200"
+	config[api.EnvVaultToken] = "token"
+	// Check backend version
+	backendVersionCheck = false
+	isKvV2 = func(*api.Client, string) (bool, error) {
+		backendVersionCheck = true
+		return true, nil
+	}
+	client, err = New(config)
+	assert.True(t, backendVersionCheck, "expected backend version check")
+	assert.Nil(t, err)
+	assert.NotNil(t, client)
+
 	isKvV2 = oldIsKvV2
+
 }


### PR DESCRIPTION
- This will allow skipping the backend version check during Vault instance
  creation, which means secrets library does not need permissions to read sys/mounts/*