### PR TITLE
vault: fix kv backend version check

### DIFF
--- a/vault/vault.go
+++ b/vault/vault.go
@@ -307,7 +307,8 @@ func isKvBackendV2(client *api.Client, backendPath string) (bool, error) {
 	}
 
 	for path, mount := range mounts {
-		if path == backendPath {
+		// path is represented as 'path/'
+		if trimSlash(path) == trimSlash(backendPath) {
 			version := mount.Options[kvVersionKey]
 			if version == "2" {
 				return true, nil
@@ -422,6 +423,10 @@ func buildAuthConfig(config map[string]interface{}) (*auth.AuthConfig, error) {
 			"token_path": tokenPath,
 		},
 	}, nil
+}
+
+func trimSlash(in string) string {
+	return strings.Trim(in, "/")
 }
 
 func init() {


### PR DESCRIPTION
The kv version check fails if backend path has no '/' suffix.
This change fixes it.

Signed-off-by: Serhii Aheienko <serhii.aheienko@gmail.com>