### PR TITLE
vault: update auth mount path parameter

### DIFF
--- a/vault/vault.go
+++ b/vault/vault.go
@@ -30,12 +30,19 @@ const (
 
 	AuthMethodKubernetes = "kubernetes"
 
-	AuthMethod              = "VAULT_AUTH_METHOD"
-	AuthMountPath           = "VAULT_AUTH_MOUNT_PATH"
-	AuthKubernetesRole      = "VAULT_AUTH_KUBERNETES_ROLE"
+	// AuthMethod is a vault authentication method used.
+	// https://www.vaultproject.io/docs/auth#auth-methods
+	AuthMethod = "VAULT_AUTH_METHOD"
+	// AuthMountPath defines a custom auth mount path.
+	AuthMountPath = "VAULT_AUTH_MOUNT_PATH"
+	// AuthKubernetesRole is the role to authenticate against on Vault
+	AuthKubernetesRole = "VAULT_AUTH_KUBERNETES_ROLE"
+	// AuthKubernetesTokenPath is the file path to a custom JWT token to use for authentication.
+	// If omitted, the default service account token path is used.
 	AuthKubernetesTokenPath = "VAULT_AUTH_KUBERNETES_TOKEN_PATH"
 
-	AuthKubernetesMountPath = "auth/kubernetes"
+	// AuthKubernetesMountPath
+	AuthKubernetesMountPath = "kubernetes"
 )
 
 var (
@@ -414,9 +421,10 @@ func buildAuthConfig(config map[string]interface{}) (*auth.AuthConfig, error) {
 	}
 	tokenPath := getVaultParam(config, AuthKubernetesTokenPath)
 
+	authMountPath := path.Join("auth", mountPath)
 	return &auth.AuthConfig{
 		Logger:    hclog.NewNullLogger(),
-		MountPath: mountPath,
+		MountPath: authMountPath,
 		Config: map[string]interface{}{
 			"role":       role,
 			"token_path": tokenPath,


### PR DESCRIPTION
To enable a custom mount path for authentication method used command:
```
$ vault auth enable -path=my-login userpass
````
So it's a bit confusing to use `auth/my-login` as a mount parameter for secrets.

Expect `VAULT_AUTH_MOUNT_PATH` parameter to be without the 'auth/' prefix. 

Signed-off-by: Serhii Aheienko <serhii.aheienko@gmail.com>