### PR TITLE
vaulttransit: fix the new function

### DIFF
--- a/vaulttransit/vaulttransit.go
+++ b/vaulttransit/vaulttransit.go
@@ -110,7 +110,8 @@ func New(
 	client.SetToken(token)
 
 	userEncryptionKey := utils.GetVaultParam(secretConfig, EncryptionKey)
-	encryptionKey, err := ensureEncryptionKey(client, userEncryptionKey, namespace)
+	// vault namespace has been already set to the client
+	encryptionKey, err := ensureEncryptionKey(client, userEncryptionKey, "")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Signed-off-by: Serhii Aheienko <serhii.aheienko@gmail.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
Vault namespace is set twice for the `ensureEncryptionKey` function and it fails as there is no permissions for the resulting namespace. Fix it with this change.

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

