### PR TITLE
vault: add support for complete key deletion in kv v2

### DIFF
--- a/.github/workflows/canary-integration-test.yml
+++ b/.github/workflows/canary-integration-test.yml
@@ -1,0 +1,47 @@
+name: integration tests
+on:
+  pull_request:
+    branches:
+      - master
+
+defaults:
+  run:
+    # reference: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#using-a-specific-shell
+    shell: bash --noprofile --norc -eo pipefail -x {0}
+
+jobs:
+  vault:
+    runs-on: ubuntu-18.04
+    if: "contains(github.event.pull_request.labels.*.name, 'vault')"
+    steps:
+    - name: checkout
+      uses: actions/checkout@v2
+
+    - name: setup golang
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.16
+
+    - name: setup minikube
+      uses: manusa/actions-setup-minikube@v2.4.2
+      with:
+        minikube version: 'v1.21.0'
+        kubernetes version: 'v1.19.2'
+        start args: --memory 6g --cpus=2
+        github token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: deploy vault
+      run: tests/scripts/deploy-validate-vault.sh deploy
+
+    - name: run vault suite test
+      run: |
+        kubectl port-forward vault-0 8200:8200 &
+        VAULT_TOKEN=$(< vault-token) make ci-test
+
+    - name: validate vault keys are gone
+      run: tests/scripts/deploy-validate-vault.sh validate
+
+    - name: setup tmate session for debugging
+      if: failure()
+      uses: mxschmitt/action-tmate@v3
+      timeout-minutes: 120

--- a/Makefile
+++ b/Makefile
@@ -3,3 +3,6 @@ generate:
 
 unit-test:
 	go test ./...
+
+ci-test:
+	go test -timeout 1800s -v github.com/libopenstorage/secrets/vault -tags ci

--- a/secrets.go
+++ b/secrets.go
@@ -57,6 +57,11 @@ const (
 const (
 	// KeyVaultNamespace is a keyContext parameter for vault secrets.
 	KeyVaultNamespace = "vault-namespace"
+
+	// DestroySecret is a keyContext parameter for Vault secrets indicating whether the Secret should be destroyed
+	// This is only valid when Vault's KV Secret Engine is running on version 2 since by default keys are versioned and soft-deleted
+	// Activating this will PERMANENTLY delete all metadata and versions for a key
+	DestroySecret = "destroy-all-secret-versions"
 )
 
 // Secrets interface implemented by backend Key Management Systems (KMS)

--- a/tests/scripts/deploy-validate-vault.sh
+++ b/tests/scripts/deploy-validate-vault.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -ex
+
+: "${ACTION:=${1}}"
+
+#############
+# VARIABLES #
+#############
+TMPDIR=$(mktemp -d)
+
+#############
+# FUNCTIONS #
+#############
+
+function install_helm {
+  curl https://baltocdn.com/helm/signing.asc | sudo apt-key add -
+  sudo apt-get install apt-transport-https --yes
+  echo "deb https://baltocdn.com/helm/stable/debian/ all main" | sudo tee /etc/apt/sources.list.d/helm-stable-debian.list
+  sudo apt-get update
+  sudo apt-get install helm
+}
+
+function deploy_vault {
+  
+  # Install Vault with Helm
+  helm repo add hashicorp https://helm.releases.hashicorp.com
+  # helm install vault hashicorp/vault --values "${TMPDIR}/"custom-values.yaml
+  helm install vault hashicorp/vault
+  timeout 120 sh -c 'until kubectl get pods -l app.kubernetes.io/name=vault --field-selector=status.phase=Running|grep vault-0; do sleep 5; done'
+  
+  # Unseal Vault
+  VAULT_INIT_TEMP_DIR=$(mktemp)
+  kubectl exec -ti vault-0 -- vault operator init -format "json" | tee -a "$VAULT_INIT_TEMP_DIR"
+  for i in $(seq 0 2); do
+    kubectl exec -ti vault-0 -- vault operator unseal "$(jq -r ".unseal_keys_b64[$i]" "$VAULT_INIT_TEMP_DIR")"
+  done
+  kubectl get pods -l app.kubernetes.io/name=vault
+  
+  # Wait for vault to be ready once unsealed
+  while [[ $(kubectl get pods -l app.kubernetes.io/name=vault -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}') != "True" ]]; do echo "waiting vault to be ready" && sleep 1; done
+  
+  # Configure Vault
+  ROOT_TOKEN=$(jq -r '.root_token' "$VAULT_INIT_TEMP_DIR")
+  kubectl exec -it vault-0 -- vault login "$ROOT_TOKEN"
+  #enable kv engine v1 for osd and v2 for rgw encryption respectively in different path
+  kubectl exec -ti vault-0 -- vault secrets enable -path=secret/ver1 kv
+  kubectl exec -ti vault-0 -- vault secrets enable -path=secret/ver2 kv-v2
+  kubectl exec -ti vault-0 -- vault kv list || true # failure is expected
+  kubectl exec -ti vault-0 -- vault kv list || true # failure is expected
+  
+  # Configure Vault Policy
+  echo '
+  path "secret/*" {
+    capabilities = ["create", "read", "update", "delete", "list"]
+  }
+  path "sys/mounts" {
+  capabilities = ["read"]
+  }'| kubectl exec -i vault-0 -- vault policy write secret -
+  
+  # Create a token for the integration test
+  kubectl exec vault-0 -- vault token create -policy=secret -format json |jq -r '.auth.client_token' > vault-token
+}
+
+function validate_list_secrets {
+  for path in ver1 ver2; do
+    if  kubectl -n default exec -ti vault-0 -- vault kv list secret/"$path" |grep -oqEq "No value found at"; then
+      echo "$path is not empty!"
+      exit 1
+    fi
+  done
+}
+
+########
+# MAIN #
+########
+
+case "$ACTION" in
+  deploy)
+    if [[ "$(uname)" == "Linux" ]]; then
+      sudo apt-get install jq socat -y
+      install_helm
+    fi
+    
+    deploy_vault
+  ;;
+  validate)
+    shift
+    validate_list_secrets
+  ;;
+  *)
+    echo "invalid action $ACTION" >&2
+    exit 1
+esac

--- a/vault/vault_ci_integration_test.go
+++ b/vault/vault_ci_integration_test.go
@@ -1,0 +1,75 @@
+// +build ci
+
+package vault
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hashicorp/vault/api"
+	"github.com/libopenstorage/secrets"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+type VaultTestSuite struct {
+	suite.Suite
+	configV1 map[string]interface{}
+	configV2 map[string]interface{}
+}
+
+func TestVaultSuite(t *testing.T) {
+	suite.Run(t, new(VaultTestSuite))
+}
+func (suite *VaultTestSuite) SetupConnection() {
+	token := os.Getenv("VAULT_TOKEN")
+	assert.NotEmpty(suite.T(), token)
+
+	// V1 CONFIG
+	c := make(map[string]interface{})
+	c[api.EnvVaultAddress] = "http://127.0.0.1:8200"
+	c[api.EnvVaultToken] = token
+	c[VaultBackendKey] = "v1"
+	c[VaultBackendPathKey] = "secret/ver1"
+	suite.configV1 = c
+
+	// V2 CONFIG
+	c[VaultBackendKey] = "v2"
+	c[VaultBackendPathKey] = "secret/ver2"
+	suite.configV2 = c
+}
+
+func (suite *VaultTestSuite) TestCRUD() {
+	suite.SetupConnection()
+	v1, err := New(suite.configV1)
+	assert.NoError(suite.T(), err)
+
+	suite.T().Run("create key v1", func(t *testing.T) {
+		// Build Secret
+		data := make(map[string]interface{})
+		data["foo"] = "bar"
+		err := v1.PutSecret("foo", data, nil)
+		assert.NoError(suite.T(), err)
+	})
+
+	suite.T().Run("delete key v1", func(t *testing.T) {
+		err := v1.DeleteSecret("foo", nil)
+		assert.NoError(suite.T(), err)
+	})
+
+	v2, err := New(suite.configV2)
+	assert.NoError(suite.T(), err)
+
+	suite.T().Run("create key v2", func(t *testing.T) {
+		// Build Secret
+		data := make(map[string]interface{})
+		data["foo"] = "bar"
+		err := v2.PutSecret("foo", data, nil)
+		assert.NoError(suite.T(), err)
+	})
+
+	suite.T().Run("destroy key v2", func(t *testing.T) {
+		err := v2.DeleteSecret("foo", map[string]string{secrets.DestroySecret: "true"})
+		assert.NoError(suite.T(), err)
+	})
+}

--- a/vault/vault_test.go
+++ b/vault/vault_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/vault/api"
+	"github.com/libopenstorage/secrets"
 	"github.com/libopenstorage/secrets/vault/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -220,7 +221,7 @@ func TestKeyPath(t *testing.T) {
 			isKvBackendV2: tc.isKV2,
 		}
 
-		spath := v.keyPath(tc.id, tc.namespace)
+		spath := v.keyPath(tc.id, map[string]string{secrets.KeyVaultNamespace: tc.namespace})
 		require.Equalf(t, tc.expected, spath.Path(), "TC#%d", i)
 	}
 }


### PR DESCRIPTION
This commit introduces a way to hard-delete all versioned key from a
Vault Secret Engine configured with version 2.
By default keys are soft-deleted, so the delete can be undone and any
version/revision of the key can be recovered.
However, there are scenarios where we want to remove everthing.

This commit expands the keyContext by adding `DestroySecret` which ones
set to any value will destroy the key. This effectively impplement this
API spec: https://www.vaultproject.io/api/secret/kv/kv-v2#delete-metadata-and-all-versions

Also, integration tests have been added to run through github actions.
I've notificed the existence of `vault/vault_ci_integration_test.go`
but I suspect it's used by another CI elsewhere so I didn't touch it.
I've tried to integrate with it at first, but couldn't find any ways to
not edit it so I prefered to leave it this way and add another detected
file for the upstream CI.
The new action will **only** run if the vault label is applied to the PR
so this won't disturb any other PRs.

This can be easily changed though.

Signed-off-by: Sébastien Han <seb@redhat.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

