### PR TITLE
PWX-17627: Adding IMDSv2 support

### DIFF
--- a/aws/credentials/credentials.go
+++ b/aws/credentials/credentials.go
@@ -31,10 +31,10 @@ func NewAWSCredentials(id, secret, token string) (AWSCredentials, error) {
 			&credentials.EnvProvider{},
 		}
 		// Check if we are running on EC2 instance
-		client := http.Client{Timeout: time.Second * 10}
-		url := "http://169.254.169.254/latest/meta-data/"
-		res, err := client.Get(url)
+		c := ec2metadata.New(session.New())
+		_, err := c.GetMetadata("mac")
 		if err == nil {
+			client := http.Client{Timeout: time.Second * 10}
 			sess := session.Must(session.NewSession())
 			ec2RoleProvider := &ec2rolecreds.EC2RoleProvider{
 				Client: ec2metadata.New(sess, &aws.Config{
@@ -42,7 +42,6 @@ func NewAWSCredentials(id, secret, token string) (AWSCredentials, error) {
 				}),
 			}
 			providers = append(providers, ec2RoleProvider)
-			res.Body.Close()
 		}
 		providers = append(providers, &credentials.SharedCredentialsProvider{})
 		creds = credentials.NewChainCredentials(providers)


### PR DESCRIPTION
      Adding IMDSv2 support. Removing custom metadata function in favor of
      aws api available in the sdk.
      More info: https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
IMDSv2 only nodes will not be able to respond to the previous metadata url. AWS SDK has the ability to try both v2 and v1.

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:
Testing: Ran px on a IMDSv2 only node.
