### PR TITLE
PWX-20521: Scaling GetProvider()

### DIFF
--- a/aws/aws_kms.go
+++ b/aws/aws_kms.go
@@ -93,7 +93,7 @@ func New(
 	if err != nil {
 		return nil, err
 	}
-	asc, err := sc.NewAWSCredentials(id, secret, token)
+	asc, err := sc.NewAWSCredentials(id, secret, token, true)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to get credentials: %v", err)
 	}

--- a/aws/credentials/credentials.go
+++ b/aws/credentials/credentials.go
@@ -19,7 +19,7 @@ type awsCred struct {
 	creds *credentials.Credentials
 }
 
-func NewAWSCredentials(id, secret, token string) (AWSCredentials, error) {
+func NewAWSCredentials(id, secret, token string, runningOnEc2 bool) (AWSCredentials, error) {
 	var creds *credentials.Credentials
 	if id != "" && secret != "" {
 		creds = credentials.NewStaticCredentials(id, secret, token)
@@ -30,10 +30,7 @@ func NewAWSCredentials(id, secret, token string) (AWSCredentials, error) {
 		providers := []credentials.Provider{
 			&credentials.EnvProvider{},
 		}
-		// Check if we are running on EC2 instance
-		c := ec2metadata.New(session.New())
-		_, err := c.GetMetadata("mac")
-		if err == nil {
+		if runningOnEc2 {
 			client := http.Client{Timeout: time.Second * 10}
 			sess := session.Must(session.NewSession())
 			ec2RoleProvider := &ec2rolecreds.EC2RoleProvider{


### PR DESCRIPTION
      GetProvider() function could not scale well when we tried to scale px
      to 400 nodes. GetProvider() function was limited by api rate limiting
      on EC2 side. This improvement patch takes care of two main things:
      1. Minimizes the amount of GetMetadata() calls that we need to make.
      2. Have an exponential backoff when such a limit is seen. There is an
         additional issue to handle here which relates to the type of error
         that is returned. Client timing out and EC2Metadata error are two
         other forms of rate limit being hit for EC2 apis. This has been
         handled by adding them to the list of errors that will undergo
         exponential backoff.

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
See description above

**Which issue(s) this PR fixes** (optional)
Closes #PWX-20521

**Special notes for your reviewer**:
This is part of a multi-part review. PRs opened on other repos like cloudops and porx.
