### PR TITLE
k8s: fix GetSecret for non-existent secret, ErrInvalidSecretId

### DIFF
--- a/k8s/k8s.go
+++ b/k8s/k8s.go
@@ -3,6 +3,8 @@ package k8s
 import (
 	"fmt"
 
+	"strings"
+
 	"github.com/libopenstorage/secrets"
 	"github.com/portworx/sched-ops/k8s/core"
 )
@@ -35,11 +37,11 @@ func (s *k8sSecrets) GetSecret(
 
 	secret, err := core.Instance().GetSecret(secretName, namespace)
 	if err != nil {
+		if strings.Contains(err.Error(), "not found") {
+			return nil, secrets.ErrInvalidSecretId
+		}
 		return nil, fmt.Errorf("Failed to get secret [%s]. Err: %v",
 			secretName, err)
-	}
-	if secret == nil {
-		return nil, secrets.ErrInvalidSecretId
 	}
 
 	data := make(map[string]interface{})


### PR DESCRIPTION
<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:

    k8s: fix GetSecret for non-existent secret, ErrInvalidSecretId

    - GetSecret returns ErrInvalidSecretId, when secret not found.
    - Fix k8s handling of k8s secret "not found" path
  

**Which issue(s) this PR fixes** (optional)
Closes #

**Special notes for your reviewer**:

