### PR TITLE
PWX-19815 Add fix for message too long problem in google kms

### DIFF
--- a/.github/workflows/google-kms-integraion-test.yml
+++ b/.github/workflows/google-kms-integraion-test.yml
@@ -18,7 +18,6 @@ jobs:
       uses: google-github-actions/auth@v0.7.0
       with:
         credentials_json: ${{ secrets.GOOGLE_CREDENTIALS }}
-        create_credentials_file: false
 
     - name: setup golang
       uses: actions/setup-go@v2

--- a/.github/workflows/google-kms-integraion-test.yml
+++ b/.github/workflows/google-kms-integraion-test.yml
@@ -15,6 +15,7 @@ jobs:
       uses: google-github-actions/auth@v0.7.0
       with:
         credentials_json: ${{ secrets.GOOGLE_CREDENTIALS }}
+        create_credentials_file: false
 
     - name: checkout
       uses: actions/checkout@v2

--- a/.github/workflows/google-kms-integraion-test.yml
+++ b/.github/workflows/google-kms-integraion-test.yml
@@ -1,0 +1,30 @@
+name: Google KMS integration test
+on:
+  pull_request:
+    branches:
+      - master
+
+
+jobs:
+  run-integrationtest:
+    runs-on: ubuntu-latest
+
+    steps:
+    # Setup gcloud CLI
+    - name: Authenticate to Google Cloud
+      uses: google-github-actions/auth@v0.7.0
+      with:
+        credentials_json: ${{ secrets.GOOGLE_CREDENTIALS }}
+
+    - name: checkout
+      uses: actions/checkout@v2
+
+    - name: setup golang
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.16
+    
+    - name: run gcloud kms integration test
+      run: |
+        export GOOGLE_KMS_RESOURCE_ID=${{secrets.GOOGLE_KMS_RESOURCE_ID}}
+        go test -v gcloud/gcloud_kms_integration_test.go gcloud/gcloud_kms.go 

--- a/.github/workflows/google-kms-integraion-test.yml
+++ b/.github/workflows/google-kms-integraion-test.yml
@@ -10,15 +10,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - name: checkout
+      uses: actions/checkout@v2
+
     # Setup gcloud CLI
     - name: Authenticate to Google Cloud
       uses: google-github-actions/auth@v0.7.0
       with:
         credentials_json: ${{ secrets.GOOGLE_CREDENTIALS }}
         create_credentials_file: false
-
-    - name: checkout
-      uses: actions/checkout@v2
 
     - name: setup golang
       uses: actions/setup-go@v2

--- a/gcloud/gcloud_kms.go
+++ b/gcloud/gcloud_kms.go
@@ -243,8 +243,13 @@ func encryptPlaintextByChunks(plainTextByte []byte, rsaKey *rsa.PublicKey, hash 
 }
 
 // splitChunk splits the plaintextByte into an array of byte array
-// each byte array has maximum size defined by the limit
+// each byte array has maximum size of `limit`
 func splitChunk(plainTextByte []byte, limit int) [][]byte {
+	if limit <= 0 {
+		// this should never happen. but we shouldn't break the flow,
+		// return the original input for EncryptOAEP to return the error
+		return [][]byte{plainTextByte}
+	}
 	chunks := make([][]byte, 0, len(plainTextByte)/limit+1)
 	var chunk []byte
 	for len(plainTextByte) >= limit {

--- a/gcloud/gcloud_kms.go
+++ b/gcloud/gcloud_kms.go
@@ -201,7 +201,7 @@ func decryptToPlaintext(g *gcloudKmsSecrets, dek []byte) ([]byte, error) {
 	var dekMap map[int][]byte
 	var err error
 	if err = json.Unmarshal(dek, &dekMap); err != nil {
-		fmt.Println("error deseralizing gcloud dek, returning the entire dek input for backward Compatibility")
+		fmt.Printf("error deseralizing gcloud dek, returning the entire dek input for backward compatibility. deserialize err: %v\n", err)
 		dekMap = make(map[int][]byte)
 		dekMap[0] = dek
 	}

--- a/gcloud/gcloud_kms.go
+++ b/gcloud/gcloud_kms.go
@@ -201,7 +201,6 @@ func decryptToPlaintext(g *gcloudKmsSecrets, dek []byte) ([]byte, error) {
 	var dekMap map[int][]byte
 	var err error
 	if err = json.Unmarshal(dek, &dekMap); err != nil {
-		fmt.Printf("error deseralizing gcloud dek, returning the entire dek input for backward compatibility. deserialize err: %v\n", err)
 		dekMap = make(map[int][]byte)
 		dekMap[0] = dek
 	}
@@ -228,7 +227,7 @@ func decryptToPlaintext(g *gcloudKmsSecrets, dek []byte) ([]byte, error) {
 	return plaintext, nil
 }
 
-// encryptPlaintextByChunks divids the plainTextBytes into chunks that are within the limit. Then
+// encryptPlaintextByChunks divides the plainTextBytes into chunks that are within the limit. Then
 // encrypts each chunk one by one and store them in map. Finally return the serialized map.
 func encryptPlaintextByChunks(plainTextByte []byte, rsaKey *rsa.PublicKey, hash hash.Hash) ([]byte, error) {
 	limit := getRSALimit(rsaKey, &hash)

--- a/gcloud/gcloud_kms_test.go
+++ b/gcloud/gcloud_kms_test.go
@@ -23,3 +23,15 @@ func TestNew(t *testing.T) {
 	_, err = New(secretConfig)
 	assert.EqualError(t, err, ErrInvalidKvdbProvided.Error(), "Unepxected error when Kvdb Key not provided")
 }
+
+func TestSplit(t *testing.T) {
+	input := []byte{1, 2, 3, 4, 5}
+	expected := [][]byte{{1, 2}, {3, 4}, {5}}
+
+	output := splitChunk(input, 2)
+	assert.Equal(t, output, expected)
+
+	output = splitChunk(input, 0)
+	expected = [][]byte{{1, 2, 3, 4, 5}}
+	assert.Equal(t, output, expected)
+}


### PR DESCRIPTION
Signed-off-by: dahuang <dahuang@purestorage.com>

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**What this PR does / why we need it**:
We were facing issue with message too long when encrypting data with google KMS. This PR adds the functionality to divide the incoming data into chunks and encrypt/decrypt them one by one.

**Which issue(s) this PR fixes** (optional)
PWX-19815

**Special notes for your reviewer**:
Testing notes:
tested locally with 2.9.1.3 cluster with `pxctl cred create` and `pxctl cred validate` with google kms and google credentials. 

all unit test + integration test passed locally

