### PR TITLE
Update job runner versions

### DIFF
--- a/.github/workflows/aws-scm-integration-test.yml
+++ b/.github/workflows/aws-scm-integration-test.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   run-integrationtest:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
     - name: checkout

--- a/.github/workflows/canary-integration-test.yml
+++ b/.github/workflows/canary-integration-test.yml
@@ -11,7 +11,7 @@ defaults:
 
 jobs:
   vault:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
     - name: checkout
       uses: actions/checkout@v2

--- a/.github/workflows/canary-integration-test.yml
+++ b/.github/workflows/canary-integration-test.yml
@@ -11,7 +11,7 @@ defaults:
 
 jobs:
   vault:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - name: checkout
       uses: actions/checkout@v2

--- a/.github/workflows/canary-integration-test.yml
+++ b/.github/workflows/canary-integration-test.yml
@@ -11,6 +11,7 @@ defaults:
 
 jobs:
   vault:
+    # Minikube setup requires ubuntu 18.04 or 20.04.
     runs-on: ubuntu-20.04
     steps:
     - name: checkout


### PR DESCRIPTION
**What this PR does / why we need it**:
Github can't find matching runners for `18.04`, switching to latest ubuntu will avoid this.

