### PR TITLE
Update minikube setup versions

### DIFF
--- a/.github/workflows/canary-integration-test.yml
+++ b/.github/workflows/canary-integration-test.yml
@@ -24,8 +24,8 @@ jobs:
     - name: setup minikube
       uses: manusa/actions-setup-minikube@v2.4.2
       with:
-        minikube version: 'v1.21.0'
-        kubernetes version: 'v1.19.2'
+        minikube version: 'v1.30.1'
+        kubernetes version: 'v1.22.17'
         start args: --memory 6g --cpus=2
         github token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/canary-integration-test.yml
+++ b/.github/workflows/canary-integration-test.yml
@@ -11,7 +11,7 @@ defaults:
 
 jobs:
   vault:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - name: checkout
       uses: actions/checkout@v2


### PR DESCRIPTION
**What this PR does / why we need it**:
The minikube setup is operating with versions which are incompatible with the vault helm chart (which isn't pinned, now requires `>=1.22`).
