### PR TITLE
PWX-33300 Use loaded credentials from sess when available

### DIFF
--- a/aws/credentials/credentials.go
+++ b/aws/credentials/credentials.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds"
+	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/session"
 )
@@ -21,18 +22,20 @@ type awsCred struct {
 
 func NewAWSCredentials(id, secret, token string, runningOnEc2 bool) (AWSCredentials, error) {
 	var creds *credentials.Credentials
+	sess := session.Must(session.NewSession())
 	if id != "" && secret != "" {
 		creds = credentials.NewStaticCredentials(id, secret, token)
 		if _, err := creds.Get(); err != nil {
 			return nil, err
 		}
+	} else if sess.Config.Credentials != nil {
+		creds = sess.Config.Credentials
 	} else {
 		providers := []credentials.Provider{
 			&credentials.EnvProvider{},
 		}
 		if runningOnEc2 {
 			client := http.Client{Timeout: time.Second * 10}
-			sess := session.Must(session.NewSession())
 			ec2RoleProvider := &ec2rolecreds.EC2RoleProvider{
 				Client: ec2metadata.New(sess, &aws.Config{
 					HTTPClient: &client,
@@ -41,6 +44,7 @@ func NewAWSCredentials(id, secret, token string, runningOnEc2 bool) (AWSCredenti
 			providers = append(providers, ec2RoleProvider)
 		}
 		providers = append(providers, &credentials.SharedCredentialsProvider{})
+		providers = append(providers, &stscreds.WebIdentityRoleProvider{})
 		creds = credentials.NewChainCredentials(providers)
 		if _, err := creds.Get(); err != nil {
 			return nil, err

--- a/aws/credentials/credentials.go
+++ b/aws/credentials/credentials.go
@@ -1,13 +1,13 @@
 package credentials
 
 import (
+	"fmt"
 	"net/http"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds"
-	"github.com/aws/aws-sdk-go/aws/credentials/stscreds"
 	"github.com/aws/aws-sdk-go/aws/ec2metadata"
 	"github.com/aws/aws-sdk-go/aws/session"
 )
@@ -22,7 +22,10 @@ type awsCred struct {
 
 func NewAWSCredentials(id, secret, token string, runningOnEc2 bool) (AWSCredentials, error) {
 	var creds *credentials.Credentials
-	sess := session.Must(session.NewSession())
+	sess, err := session.NewSession()
+	if err != nil {
+		return nil, fmt.Errorf("error crewating new aws credentials: %w", err)
+	}
 	if id != "" && secret != "" {
 		creds = credentials.NewStaticCredentials(id, secret, token)
 		if _, err := creds.Get(); err != nil {
@@ -44,7 +47,6 @@ func NewAWSCredentials(id, secret, token string, runningOnEc2 bool) (AWSCredenti
 			providers = append(providers, ec2RoleProvider)
 		}
 		providers = append(providers, &credentials.SharedCredentialsProvider{})
-		providers = append(providers, &stscreds.WebIdentityRoleProvider{})
 		creds = credentials.NewChainCredentials(providers)
 		if _, err := creds.Get(); err != nil {
 			return nil, err

--- a/aws/credentials/credentials.go
+++ b/aws/credentials/credentials.go
@@ -32,6 +32,8 @@ func NewAWSCredentials(id, secret, token string, runningOnEc2 bool) (AWSCredenti
 			return nil, err
 		}
 	} else if sess.Config.Credentials != nil {
+		// sess config loads credential automatically from environment variable
+		// this is used to prioritize loading aws web identity token whenever it's specified.
 		creds = sess.Config.Credentials
 	} else {
 		providers := []credentials.Provider{


### PR DESCRIPTION
**What this PR does / why we need it**:
we need to load web identity credentials from env and it's loaded automatically when new session is established. this commit uses it whenever it's there

**Which issue(s) this PR fixes**
JIRA: PWX-33300

<!--
  Make sure to have done the following:
  [] Signed off your work as per the DCO.
  [] Add unit-tests
-->

**Special notes for your reviewer**:
testing note:
- used this change in mpxe-api to load from webidentity provider. In fact, it loads the ec2role credentials as well. But I don't want to change the behavior of current code, so i'm simply adding the check instead of removing the ec2role provider.

